### PR TITLE
downgrading pg db from 14.5 to 10.21 until OpenShift supports it

### DIFF
--- a/docker-compose.local.yaml
+++ b/docker-compose.local.yaml
@@ -39,7 +39,7 @@ services:
   ###                                       Database                                        ###
   #############################################################################################
   dpia-db:
-    image: postgres:14.5-alpine
+    image: postgres:10.21-alpine3.16
     restart: always
     env_file: ./src/backend/.env
     ports:


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- downgrading pg db from 14.5 to 10.21 until OpenShift supports it

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring / Documentation
- [ ] Version change

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Development Dependency Working Agreement
- [x] My code DOES NOT include the importing of new dependencies into the DPIA ecosystem
- [ ] My code DOES include the importing of new dependencies into the DPIA ecosystem
**If new dependencies are being introduced to the DPIA ecosystem:**
- [ ] The functionality of the dependency drastically reduces code complexity and makes my changes more easily maintainable and readible 
- [ ] The dependency being introduced does not contain multiple layers of nested dependencies introducing maintainability complexity to the DPIA ecosystem

## Frontend Development Changes
- [x] N/A
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to project documentation or diagrams that reflect my changes
- [ ] New and existing unit tests pass locally with my changes
- [ ] My code follows Airbnb React Style Guidelines

## API Development Changes
- [x] N/A
- [ ] I have performed a self-review of my own code
- [ ] My code follows standards and practices outlined in the BC Government API Development Guidelines
- [ ] New and existing unit tests pass locally with my changes
- [ ] My changes includes Swagger documentation updates that reflect the changes I am introducing
