### PR TITLE
[UTOPIA-351] [Frontend] removed env support to align with same base route strategy

### DIFF
--- a/docker-compose.local.yaml
+++ b/docker-compose.local.yaml
@@ -29,8 +29,6 @@ services:
     build:
       context: ./src/frontend
       dockerfile: .docker/Dockerfile.local
-    env_file:
-      - ./src/frontend/.env
     volumes:
     # Binds the application folder from the host inside the container for fast changes
       - ./src/frontend:/app

--- a/src/frontend/.config/.env.local
+++ b/src/frontend/.config/.env.local
@@ -1,4 +1,2 @@
-VITE_REACT_API_HOST=localhost
-VITE_REACT_API_PORT=3000
-VITE_PORT=8080
-VITE_REACT_API_BASE_URL=http://localhost:3000
+# TODO - envs to be loaded at run time from a config endpoint; Removing env contents here; 
+# For vite build configs, refer vite.config.local.ts or vite.config.ts accordingly

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "version": "0.0.0",
   "scripts": {
-    "dev": "vite",
+    "dev": "vite --config vite.config.local.ts",
     "build": "tsc && vite build",
     "preview": "vite preview",
     "prettier": "prettier src -check",

--- a/src/frontend/src/constant/api.ts
+++ b/src/frontend/src/constant/api.ts
@@ -1,7 +1,0 @@
-/**
- * @file api.ts
- *
- * Contains constants relevant to API URLs.
- */
-
-export const BASE_URL = import.meta.env.VITE_REACT_API_BASE_URL;

--- a/src/frontend/src/utils/requestUtil.ts
+++ b/src/frontend/src/utils/requestUtil.ts
@@ -1,5 +1,3 @@
-import { BASE_URL } from '../constant/api';
-
 export const httpClient = async (
   endpoint: string,
   body: any,
@@ -14,7 +12,7 @@ export const httpClient = async (
     ...customConfig,
   };
 
-  const response = await fetch(`${BASE_URL}/${endpoint}`, options);
+  const response = await fetch(`/${endpoint}`, options);
   if (!response.ok) {
     throw new Error(`HTTP error! status: ${response.status}`);
   }

--- a/src/frontend/vite.config.local.ts
+++ b/src/frontend/vite.config.local.ts
@@ -2,7 +2,7 @@ import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 
 // https://vitejs.dev/config/
-export default defineConfig(({ mode }) => {
+export default defineConfig(() => {
   return {
     plugins: [react()],
     build: {
@@ -11,6 +11,13 @@ export default defineConfig(({ mode }) => {
     server: {
       host: true,
       port: 8080,
+      proxy: {
+        '/api': {
+          target: 'http://dpia-api:3000',
+          changeOrigin: true,
+          secure: false,
+        },
+      },
     },
   };
 });


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- Removed env to align with same base route strategy
- Added proxy support for local development where same base route strategy won't work with apps running on separate ports

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring / Documentation
- [ ] Version change

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Development Dependency Working Agreement
- [x] My code DOES NOT include the importing of new dependencies into the DPIA ecosystem
- [ ] My code DOES include the importing of new dependencies into the DPIA ecosystem
**If new dependencies are being introduced to the DPIA ecosystem:**
- [ ] The functionality of the dependency drastically reduces code complexity and makes my changes more easily maintainable and readible 
- [ ] The dependency being introduced does not contain multiple layers of nested dependencies introducing maintainability complexity to the DPIA ecosystem

## Frontend Development Changes
- [ ] N/A
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to project documentation or diagrams that reflect my changes
- [ ] New and existing unit tests pass locally with my changes
- [x] My code follows Airbnb React Style Guidelines

## API Development Changes
- [x] N/A
- [ ] I have performed a self-review of my own code
- [ ] My code follows standards and practices outlined in the BC Government API Development Guidelines
- [ ] New and existing unit tests pass locally with my changes
- [ ] My changes includes Swagger documentation updates that reflect the changes I am introducing
