### PR TITLE
[UTOPIA-273] [Backend] fix pdf output when proposedStartDate field is null

### DIFF
--- a/src/backend/src/modules/ppq/ppq.service.ts
+++ b/src/backend/src/modules/ppq/ppq.service.ts
@@ -103,7 +103,9 @@ export class PpqService {
         ministry: ministry || 'NA',
         branch: ppqForm.branch || 'N/A',
         piaType: piaType || 'N/A',
-        proposedStartDate: shortDate(ppqForm.proposedStartDate) || 'N/A',
+        proposedStartDate: ppqForm.proposedStartDate
+          ? shortDate(ppqForm.proposedStartDate)
+          : 'N/A',
         containsPersonalInformation,
         initiativeDescription: marked.parse(ppqForm.initiativeDescription),
         dataElements: marked.parse(ppqForm.dataElements),


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- Identified an issue during own testing that the proposedStartDate when passed null was printing a 1970 date on PDF

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

## How Has This Been Tested?

This issues came up as part of the personal testing. Verified the fix by passing null date from frontend.

## Development Dependency Working Agreement
- [x] My code DOES NOT include the importing of new dependencies into the DPIA ecosystem
- [ ] My code DOES include the importing of new dependencies into the DPIA ecosystem
**If new dependencies are being introduced to the DPIA ecosystem:**
- [ ] The functionality of the dependency drastically reduces code complexity and makes my changes more easily maintainable and readible 
- [ ] The dependency being introduced does not contain multiple layers of nested dependencies introducing maintainability complexity to the DPIA ecosystem

## Frontend Development Changes
- [x] N/A
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to project documentation or diagrams that reflect my changes
- [ ] New and existing unit tests pass locally with my changes
- [ ] My code follows Airbnb React Style Guidelines

## API Development Changes
- [ ] N/A
- [x] I have performed a self-review of my own code
- [x] My code follows standards and practices outlined in the BC Government API Development Guidelines
- [x] New and existing unit tests pass locally with my changes
- [ ] My changes includes Swagger documentation updates that reflect the changes I am introducing
