### PR TITLE
[UTOPIA-381] Added migration and changes to remove fields not required anymore

### DIFF
--- a/src/backend/src/migrations/1666983517409-ppq-form-update-other-factors-fields.ts
+++ b/src/backend/src/migrations/1666983517409-ppq-form-update-other-factors-fields.ts
@@ -1,0 +1,21 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class PpqFormUpdateOtherFactorsFields1666983517409
+  implements MigrationInterface
+{
+  name = 'ppqFormUpdateOtherFactorsFields1666983517409';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "ppq" DROP COLUMN "has_high_volumes_personal_information"`,
+    );
+    await queryRunner.query(`ALTER TABLE "ppq" DROP COLUMN "has_data_linking"`);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "ppq" ADD "has_data_linking" boolean`);
+    await queryRunner.query(
+      `ALTER TABLE "ppq" ADD "has_high_volumes_personal_information" boolean`,
+    );
+  }
+}

--- a/src/backend/src/modules/ppq/constants/ppq-other-factors.constant.ts
+++ b/src/backend/src/modules/ppq/constants/ppq-other-factors.constant.ts
@@ -28,14 +28,6 @@ export const PpqOtherFactors = [
     value: 'hasDisclosureOutsideOfCanada',
   },
   {
-    label: 'High volumes of personal information',
-    value: 'hasHighVolumesPersonalInformation',
-  },
-  {
-    label: 'Data-linking',
-    value: 'hasDataLinking',
-  },
-  {
     label: 'BC Services Card Onboarding',
     value: 'hasBcServicesCardOnboarding',
   },

--- a/src/backend/src/modules/ppq/dto/ppq-post.dto.ts
+++ b/src/backend/src/modules/ppq/dto/ppq-post.dto.ts
@@ -158,24 +158,6 @@ export class PpqPostDTO {
     required: false,
     example: false,
   })
-  hasHighVolumesPersonalInformation: boolean;
-
-  @IsBoolean()
-  @IsOptional()
-  @ApiProperty({
-    type: Boolean,
-    required: false,
-    example: false,
-  })
-  hasDataLinking: boolean;
-
-  @IsBoolean()
-  @IsOptional()
-  @ApiProperty({
-    type: Boolean,
-    required: false,
-    example: false,
-  })
   hasBcServicesCardOnboarding: boolean;
 
   @IsBoolean()

--- a/src/backend/src/modules/ppq/entities/ppq.entity.ts
+++ b/src/backend/src/modules/ppq/entities/ppq.entity.ts
@@ -93,20 +93,6 @@ export class PpqEntity extends BaseEntity {
   hasDisclosureOutsideOfCanada: boolean;
 
   @Column({
-    name: 'has_high_volumes_personal_information',
-    type: 'boolean',
-    nullable: true,
-  })
-  hasHighVolumesPersonalInformation: boolean;
-
-  @Column({
-    name: 'has_data_linking',
-    type: 'boolean',
-    nullable: true,
-  })
-  hasDataLinking: boolean;
-
-  @Column({
     name: 'has_bc_services_card_onboarding',
     type: 'boolean',
     nullable: true,

--- a/src/frontend/src/pages/PPQFormPage/PPQFormPage.tsx
+++ b/src/frontend/src/pages/PPQFormPage/PPQFormPage.tsx
@@ -68,8 +68,6 @@ const PPQFormPage = () => {
     hasCloudTechnology: false,
     hasPotentialPublicInterest: false,
     hasDisclosureOutsideOfCanada: false,
-    hasHighVolumesPersonalInformation: false,
-    hasDataLinking: false,
     hasBcServicesCardOnboarding: false,
     hasAiOrMl: false,
     hasPartnershipNonMinistry: false,

--- a/src/frontend/src/ts/interfaces/ppq-form.interface.ts
+++ b/src/frontend/src/ts/interfaces/ppq-form.interface.ts
@@ -18,8 +18,6 @@ export interface IPPQFrom {
   hasCloudTechnology?: boolean;
   hasPotentialPublicInterest?: boolean;
   hasDisclosureOutsideOfCanada?: boolean;
-  hasHighVolumesPersonalInformation?: boolean;
-  hasDataLinking?: boolean;
   hasBcServicesCardOnboarding?: boolean;
   hasAiOrMl?: boolean;
   hasPartnershipNonMinistry?: boolean;


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- Migration removing fields - `has_high_volumes_personal_information`, `has_data_linking `
- Removes references to the above fields

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

## How Has This Been Tested?

Verified that the app is working as expected after the migration is run

## Development Dependency Working Agreement
- [x] My code DOES NOT include the importing of new dependencies into the DPIA ecosystem
- [ ] My code DOES include the importing of new dependencies into the DPIA ecosystem
**If new dependencies are being introduced to the DPIA ecosystem:**
- [ ] The functionality of the dependency drastically reduces code complexity and makes my changes more easily maintainable and readible 
- [ ] The dependency being introduced does not contain multiple layers of nested dependencies introducing maintainability complexity to the DPIA ecosystem

## Frontend Development Changes
- [x] N/A
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to project documentation or diagrams that reflect my changes
- [ ] New and existing unit tests pass locally with my changes
- [ ] My code follows Airbnb React Style Guidelines

## API Development Changes
- [x] N/A
- [x] I have performed a self-review of my own code
- [ ] My code follows standards and practices outlined in the BC Government API Development Guidelines
- [x] New and existing unit tests pass locally with my changes
- [ ] My changes includes Swagger documentation updates that reflect the changes I am introducing
