### PR TITLE
UTOPIA-400: View bottom of screen instead of top

### DIFF
--- a/src/frontend/src/components/common/ScrollToTop/index.ts
+++ b/src/frontend/src/components/common/ScrollToTop/index.ts
@@ -5,11 +5,10 @@ const ScrollToTop = () => {
   const { pathname } = useLocation();
 
   useEffect(() => {
-    // "document.documentElement.scrollTo" is the magic for React Router Dom v6
     document.documentElement.scrollTo({
       top: 0,
       left: 0,
-      behavior: 'auto', // Optional if you want to skip the scrolling animation
+      behavior: 'auto',
     });
   }, [pathname]);
 

--- a/src/frontend/src/components/common/ScrollToTop/index.ts
+++ b/src/frontend/src/components/common/ScrollToTop/index.ts
@@ -1,0 +1,19 @@
+import { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
+
+const ScrollToTop = () => {
+  const { pathname } = useLocation();
+
+  useEffect(() => {
+    // "document.documentElement.scrollTo" is the magic for React Router Dom v6
+    document.documentElement.scrollTo({
+      top: 0,
+      left: 0,
+      behavior: 'auto', // Optional if you want to skip the scrolling animation
+    });
+  }, [pathname]);
+
+  return null;
+};
+
+export default ScrollToTop;

--- a/src/frontend/src/main.tsx
+++ b/src/frontend/src/main.tsx
@@ -4,9 +4,11 @@ import App from './App';
 import './sass/index.scss';
 import './sass/common.scss';
 import { BrowserRouter } from 'react-router-dom';
+import ScrollToTop from './components/common/ScrollToTop';
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <BrowserRouter>
+    <ScrollToTop />
     <App />
   </BrowserRouter>,
 );


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- Creates ScrollToTop component to handle scrolling to the top of the page on re-route

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

## How Has This Been Tested?

Clicked 'Next' on PPQ form page and confirmed the page scrolls to top on re-route.

## Development Dependency Working Agreement
- [x] My code DOES NOT include the importing of new dependencies into the DPIA ecosystem
- [ ] My code DOES include the importing of new dependencies into the DPIA ecosystem
**If new dependencies are being introduced to the DPIA ecosystem:**
- [ ] The functionality of the dependency drastically reduces code complexity and makes my changes more easily maintainable and readible 
- [ ] The dependency being introduced does not contain multiple layers of nested dependencies introducing maintainability complexity to the DPIA ecosystem

## Frontend Development Changes
- [ ] N/A
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to project documentation or diagrams that reflect my changes
- [ ] New and existing unit tests pass locally with my changes
- [ ] My code follows Airbnb React Style Guidelines

## API Development Changes
- [x] N/A
- [ ] I have performed a self-review of my own code
- [ ] My code follows standards and practices outlined in the BC Government API Development Guidelines
- [ ] New and existing unit tests pass locally with my changes
- [ ] My changes includes Swagger documentation updates that reflect the changes I am introducing
