### PR TITLE
[UTOPIA-438]update pia intake results page download btn css

### DIFF
--- a/src/frontend/src/components/public/PIAIntakeResults/index.tsx
+++ b/src/frontend/src/components/public/PIAIntakeResults/index.tsx
@@ -63,7 +63,7 @@ const PIAIntakeResults = (props: IComponentProps) => {
       <section className="download-results">
         <h2>{Messages.Headings.StepTwo.en}</h2>
         <button
-          className={`btn-secondary ${
+          className={`bcgovbtn bcgovbtn__secondary ${
             isDownloading ? 'opacity-50 pe-none' : ''
           }`}
           onClick={handleDownload}


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- fix pia intake result page download btn css
<img width="1573" alt="Screen Shot 2022-11-29 at 3 05 22 PM" src="https://user-images.githubusercontent.com/57013495/204667934-65763b96-97eb-40ec-8dc4-84c2ef8509e1.png">



## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Development Dependency Working Agreement
- [x] My code DOES NOT include the importing of new dependencies into the DPIA ecosystem
- [ ] My code DOES include the importing of new dependencies into the DPIA ecosystem
**If new dependencies are being introduced to the DPIA ecosystem:**
- [ ] The functionality of the dependency drastically reduces code complexity and makes my changes more easily maintainable and readible 
- [ ] The dependency being introduced does not contain multiple layers of nested dependencies introducing maintainability complexity to the DPIA ecosystem

## Frontend Development Changes
- [ ] N/A
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to project documentation or diagrams that reflect my changes
- [ ] New and existing unit tests pass locally with my changes
- [ ] My code follows Airbnb React Style Guidelines

## API Development Changes
- [x] N/A
- [ ] I have performed a self-review of my own code
- [ ] My code follows standards and practices outlined in the BC Government API Development Guidelines
- [ ] New and existing unit tests pass locally with my changes
- [ ] My changes includes Swagger documentation updates that reflect the changes I am introducing

## Definition of Done

![Definition of Done](https://raw.githubusercontent.com/bcgov/cirmo-dpia/main/.github/assets/DoD.jpg)
