### PR TITLE
[UTOPIA-579] [Frontend] All endpoints including Logout behind auth except Login and callback

### DIFF
--- a/src/frontend/src/components/common/Header/Header.tsx
+++ b/src/frontend/src/components/common/Header/Header.tsx
@@ -55,12 +55,7 @@ function Header({ user }: Props) {
             storeTokens(keycloakToken);
             setAuthenticated(true);
             setAccessToken(keycloakToken.access_token);
-            const res = await HttpRequest.get<IConfig>(
-              API_ROUTES.CONFIG_FILE,
-              {},
-              {},
-              true,
-            );
+            const res = await HttpRequest.get<IConfig>(API_ROUTES.CONFIG_FILE);
             setItemInStorage('config', res);
             navigate(routes.PPQ_LANDING_PAGE);
           }
@@ -98,6 +93,7 @@ function Header({ user }: Props) {
     };
 
     await HttpRequest.post(API_ROUTES.KEYCLOAK_LOGOUT, keycloakTokenObj);
+
     clearTokens();
     setAccessToken(null);
     navigate('/');

--- a/src/frontend/src/hooks/usePIALookup.ts
+++ b/src/frontend/src/hooks/usePIALookup.ts
@@ -12,12 +12,7 @@ export const usePIALookup = () => {
       try {
         // Actually perform fetch
         const results = (
-          await HttpRequest.get<IPIAResults>(
-            API_ROUTES.PIA_INTAKE,
-            {},
-            {},
-            true,
-          )
+          await HttpRequest.get<IPIAResults>(API_ROUTES.PIA_INTAKE)
         ).data;
         setTableData(results);
       } catch (e) {

--- a/src/frontend/src/pages/PIAIntakeForm/index.tsx
+++ b/src/frontend/src/pages/PIAIntakeForm/index.tsx
@@ -142,9 +142,6 @@ const PIAIntakeFormPage = () => {
       const res = await HttpRequest.post<IPIAResult>(
         API_ROUTES.PIA_INTAKE,
         requestBody,
-        {},
-        {},
-        true,
       );
 
       navigate(routes.PIA_INTAKE_RESULT, {

--- a/src/frontend/src/pages/PPQFormPage/PPQFormPage.tsx
+++ b/src/frontend/src/pages/PPQFormPage/PPQFormPage.tsx
@@ -103,9 +103,6 @@ const PPQFormPage = () => {
       const res = await HttpRequest.post<IPPQResult>(
         API_ROUTES.PPQ_FORM_SUBMISSION,
         requestBody,
-        {},
-        {},
-        true,
       );
 
       navigate(routes.PPQ_CONNECT_WITH_MPO, {

--- a/src/frontend/src/utils/file-download.util.ts
+++ b/src/frontend/src/utils/file-download.util.ts
@@ -14,7 +14,6 @@ export class FileDownload {
       endpoint,
       { 'Content-Type': `application/${contentType}` },
       additionalConfig,
-      true,
     );
     const blob: Blob = await response.blob();
 

--- a/src/frontend/src/utils/getAccessToken.ts
+++ b/src/frontend/src/utils/getAccessToken.ts
@@ -8,6 +8,9 @@ export const getAccessToken = async (code: string | null) => {
   const res = await HttpRequest.post<IKeycloakToken>(
     `/${API_ROUTES.KEYCLOAK_CALLBACK}`,
     { code: code },
+    {},
+    {},
+    false,
   );
   return res;
 };

--- a/src/frontend/src/utils/http-request.util.ts
+++ b/src/frontend/src/utils/http-request.util.ts
@@ -52,7 +52,7 @@ export class HttpRequest {
     endpoint: string,
     headers: Record<string, string> = {},
     additionalConfig: Record<string, any> = {},
-    addLocalAuth = false,
+    addLocalAuth = true,
   ) {
     return this.request<T>({
       method: 'GET',
@@ -68,7 +68,7 @@ export class HttpRequest {
     body: Record<string, any>,
     headers: Record<string, string> = {},
     additionalConfig: Record<string, any> = {},
-    addLocalAuth = false,
+    addLocalAuth = true,
   ) {
     return this.request<T>({
       method: 'POST',


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- Logout is behind auth now
- Refactor to add auth by default to all endpoints except keycloakLogin and callback methods

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring / Documentation
- [ ] Version change

## How Has This Been Tested?

Tested the complete flow

## Development Dependency Working Agreement
- [x] My code DOES NOT include the importing of new dependencies into the DPIA ecosystem
- [ ] My code DOES include the importing of new dependencies into the DPIA ecosystem
**If new dependencies are being introduced to the DPIA ecosystem:**
- [ ] The functionality of the dependency drastically reduces code complexity and makes my changes more easily maintainable and readible 
- [ ] The dependency being introduced does not contain multiple layers of nested dependencies introducing maintainability complexity to the DPIA ecosystem

## Frontend Development Changes
- [ ] N/A
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to project documentation or diagrams that reflect my changes
- [ ] New and existing unit tests pass locally with my changes
- [x] My code follows Airbnb React Style Guidelines

## API Development Changes
- [x] N/A
- [ ] I have performed a self-review of my own code
- [ ] My code follows standards and practices outlined in the BC Government API Development Guidelines
- [ ] New and existing unit tests pass locally with my changes
- [ ] My changes includes Swagger documentation updates that reflect the changes I am introducing

## Definition of Done

![Definition of Done](https://raw.githubusercontent.com/bcgov/cirmo-dpia/main/.github/assets/DoD.jpg)
