### PR TITLE
UTOPIA-608: [Front End] Create UI Save before submitting modal

### DIFF
--- a/src/frontend/src/components/common/Header/Header.tsx
+++ b/src/frontend/src/components/common/Header/Header.tsx
@@ -140,6 +140,7 @@ function Header({ user }: Props) {
           cancelLabel="Cancel"
           titleText="Sign out confirmation"
           show={showModal}
+          reversed={true}
           handleClose={hideModalDialog}
           handleCancel={cancelModalDialog}
         >

--- a/src/frontend/src/components/common/Modal/_modal.scss
+++ b/src/frontend/src/components/common/Modal/_modal.scss
@@ -43,12 +43,13 @@
   }
 
   .modalbtn__container {
-    display:flex;
-    flex-direction: row;
-    justify-content:center;
-    button {
-      margin-right: 4px;
-      margin-left: 4px;
+    display: flex;
+    flex-direction: row-reverse;
+    justify-content: center;
+    gap: 0.5em;
+
+    &.reversed {
+      flex-direction: row;
     }
   }
 }

--- a/src/frontend/src/components/common/Modal/index.tsx
+++ b/src/frontend/src/components/common/Modal/index.tsx
@@ -7,6 +7,7 @@ const Modal = ({
   handleClose,
   handleCancel,
   show,
+  reversed,
   children,
 }: IModal) => {
   const showHideClassName = show
@@ -18,7 +19,7 @@ const Modal = ({
         <span className="modal-title"> {titleText}</span>
         <div className="modal-horizontal-divider"></div>
         {children}
-        <div className="modalbtn__container">
+        <div className={`modalbtn__container ${reversed ? 'reversed' : ''}`}>
           <button
             className="bcgovbtn bcgovbtn__primary "
             type="button"

--- a/src/frontend/src/components/common/Modal/interfaces.ts
+++ b/src/frontend/src/components/common/Modal/interfaces.ts
@@ -6,6 +6,7 @@ export interface IModal {
   titleText: string;
   show: boolean;
   children: any;
+  reversed?: boolean;
   handleClose: MouseEventHandler<HTMLButtonElement>;
   handleCancel: MouseEventHandler<HTMLButtonElement>;
 }

--- a/src/frontend/src/components/common/Unauthorized/index.tsx
+++ b/src/frontend/src/components/common/Unauthorized/index.tsx
@@ -11,10 +11,6 @@ const Unauthorized = () => (
       />
       <div className="row ">
         <h1 className="d-flex justify-content-center">
-<<<<<<< HEAD
-=======
-          {' '}
->>>>>>> 0f620e3 (Implements PIA intake save modal with different text content and CTAs based on which button is pressed. Had to mess with the existing modal component to allow for the 'Sign out' modal to look the same while the new modals reflect iteration 4 designs)
           401: Authorization required
         </h1>
       </div>

--- a/src/frontend/src/components/common/Unauthorized/index.tsx
+++ b/src/frontend/src/components/common/Unauthorized/index.tsx
@@ -11,6 +11,10 @@ const Unauthorized = () => (
       />
       <div className="row ">
         <h1 className="d-flex justify-content-center">
+<<<<<<< HEAD
+=======
+          {' '}
+>>>>>>> 0f620e3 (Implements PIA intake save modal with different text content and CTAs based on which button is pressed. Had to mess with the existing modal component to allow for the 'Sign out' modal to look the same while the new modals reflect iteration 4 designs)
           401: Authorization required
         </h1>
       </div>

--- a/src/frontend/src/pages/PIADetailPage/index.tsx
+++ b/src/frontend/src/pages/PIADetailPage/index.tsx
@@ -2,7 +2,7 @@ import {
   IPIAIntake,
   IPIAIntakeResponse,
 } from '../../types/interfaces/pia-intake.interface';
-import { faArrowDown } from '@fortawesome/free-solid-svg-icons';
+import { faFileArrowDown } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { dateToString } from '../../utils/date';
 import messages from './messages';
@@ -12,6 +12,14 @@ import { useEffect, useState } from 'react';
 import { HttpRequest } from '../../utils/http-request.util';
 import { API_ROUTES } from '../../constant/apiRoutes';
 import { routes } from '../../constant/routes';
+import Alert from '../../components/common/Alert';
+import MDEditor from '@uiw/react-md-editor';
+import { MinistryList, PIOptions } from '../../constant/constant';
+import {
+  FileDownload,
+  FileDownloadTypeEnum,
+} from '../../utils/file-download.util';
+import Spinner from '../../components/common/Spinner';
 
 const PIADetailPage = () => {
   // https://github.com/microsoft/TypeScript/issues/48949
@@ -20,6 +28,11 @@ const PIADetailPage = () => {
   const { id } = useParams();
   const navigate = useNavigate();
   const [pia, setPia] = useState<any>({});
+  const [fetchPiaError, setFetchPiaError] = useState('');
+  const [piaMinistryFullName, setPiaMinistryFullName] = useState('');
+  const [isDownloading, setIsDownloading] = useState(false);
+  const [downloadError, setDownloadError] = useState('');
+  const [piOption, setPIOption] = useState('');
   useEffect(() => {
     (async () => {
       try {
@@ -30,132 +43,204 @@ const PIADetailPage = () => {
           )
         ).data;
         setPia(result);
-      } catch (e: any) {
-        const errorCode: string = e.message.split(':')[1];
-        if (errorCode.includes('404')) {
-          win.location = routes.NOT_FOUND;
-        } else if (errorCode.includes('401') || errorCode.includes('403')) {
-          win.location = routes.NOT_AUTHORIZED;
-        } else {
-          throw new Error('Fetch pia failed');
+        setPiaMinistryFullName(
+          MinistryList.filter((item) => item.value === pia.ministry)[0].label,
+        );
+        setPIOption(
+          pia.hasAddedPiToDataElements === true
+            ? PIOptions[0]
+            : pia.hasAddedPiToDataElements === false
+            ? PIOptions[1]
+            : PIOptions[2],
+        );
+      } catch (e) {
+        if (e instanceof Error && e.cause instanceof Error) {
+          const errorCode = e.cause.message as unknown as string;
+          if (errorCode === '404') {
+            win.location = routes.NOT_FOUND;
+          } else if (
+            errorCode === '401' ||
+            errorCode === '403' ||
+            errorCode === '410'
+          ) {
+            win.location = routes.NOT_AUTHORIZED;
+          } else {
+            setFetchPiaError('Something went wrong. Please try again.');
+            throw new Error('Fetch pia failed');
+          }
         }
       }
     })();
-  }, [id, navigate, win]);
+  }, [id, navigate, pia.hasAddedPiToDataElements, pia.ministry, win]);
 
+  const handleAlertClose = () => {
+    setFetchPiaError('');
+    setDownloadError('');
+  };
+
+  const handleDownload = async () => {
+    setDownloadError('');
+
+    if (!id) {
+      console.error(
+        'Something went wrong. Result Id not available for download',
+      );
+      setDownloadError('Something went wrong. Please try again.');
+      return;
+    }
+
+    setIsDownloading(true);
+    try {
+      await FileDownload.download(
+        API_ROUTES.PIA_INTAKE_RESULT_DOWNLOAD.replace(':id', `${id}`),
+        FileDownloadTypeEnum.PDF,
+      );
+    } catch (e) {
+      setDownloadError('Something went wrong. Please try again.');
+    } finally {
+      setIsDownloading(false);
+    }
+  };
   return (
-    <div className="bcgovPageContainer results results-wrapper ppq-connect">
-      <div className="form__title">
-        <h1>{pia.title}</h1>
-        <a href="/pia-edit" className="bcgovbtn bcgovbtn__primary">
-          <FontAwesomeIcon icon={faArrowDown} />
-        </a>
-      </div>
-      <div>
-        <div className="row">
-          <div className="col col-md-4">Status</div>
-          <div className="col col-md-4">Submitted on</div>
-          <div className="col col-md-4">Last modified</div>
-        </div>
-        <div className="row">
-          <div className="col col-md-4">
-            {pia.status ? pia.status : 'Submitted'}
-          </div>
-          <div className="col col-md-4">{dateToString(pia.createdAt)}</div>
-          <div className="col col-md-4">{dateToString(pia.updatedAt)}</div>
-        </div>
-      </div>
-      <div className="horizontal-divider"></div>
-      <div className="container d-grid gap-3">
-        <h2>
-          <b>{messages.GeneralInfoSection.H2Text.en}</b>
-        </h2>
-        <div>
-          <div className="row ">
-            <div className="col col-md-4">
-              <b>Drafter</b>
-            </div>
-            <div className="col col-md-4">
-              <b>Initiative Lead</b>
-            </div>
-            <div className="col col-md-4">
-              <b>Ministry Privacy Officer </b>
-            </div>
-          </div>
-          <div className="row">
-            <div className="col col-md-4">{pia.drafterName}</div>
-            <div className="col col-md-4">{pia.leadName}</div>
-            <div className="col col-md-4">{pia.mpoName}</div>
-          </div>
-          <div className="row">
-            <div className="col col-md-4">{pia.drafterTitle}</div>
-            <div className="col col-md-4">{pia.leadTitle}</div>
-            <div className="col col-md-4">{pia.mpoEmail}</div>
-          </div>
-          <div className="row">
-            <div className="col col-md-4">{pia.drafterEmail}</div>
-            <div className="col col-md-4">{pia.leadEmail}</div>
-          </div>
+    <div className="bcgovPageContainer background ">
+      <div className="container__padding-inline ppq-form-section form__container row">
+        {fetchPiaError && (
+          <Alert
+            type="danger"
+            message="Something went wrong. Please try again."
+            onClose={handleAlertClose}
+            className="mt-2"
+          />
+        )}
+        {downloadError && (
+          <Alert
+            type="danger"
+            message="Something went wrong. Please try again."
+            onClose={handleAlertClose}
+            className="mt-2"
+          />
+        )}
+        <div className="form__title">
+          <h1>{pia.title}</h1>
+          <button
+            className={`bcgovbtn bcgovbtn__primary ${
+              isDownloading ? 'opacity-50 pe-none' : ''
+            }`}
+            onClick={() => handleDownload()}
+          >
+            <FontAwesomeIcon icon={faFileArrowDown} />
+            {isDownloading && <Spinner />}
+          </button>
         </div>
         <div>
           <div className="row">
-            <div className="col col-md-4">
-              <b>Ministry</b>
-            </div>
-            <div className="col col-md-4">
-              <b>Branch</b>
-            </div>
+            <div className="col col-md-4">Status</div>
+            <div className="col col-md-4">Submitted on</div>
+            <div className="col col-md-4">Last modified</div>
           </div>
           <div className="row">
-            <div className="col col-md-4">{pia.ministry}</div>
-            <div className="col col-md-4">{pia.branch}</div>
+            <div className="col col-md-4">
+              {pia.status ? pia.status : 'Submitted'}
+            </div>
+            <div className="col col-md-4">{dateToString(pia.createdAt)}</div>
+            <div className="col col-md-4">{dateToString(pia.updatedAt)}</div>
           </div>
         </div>
-      </div>
-      <div className="container pt-5">
-        <h2 className="pb-3">
-          <b>{messages.GeneralInfoSection.H2TextTwo.en}</b>
-        </h2>
-        <div>
-          <p className="pb-1">
-            {messages.InitiativeDescriptionSection.H2Text.en}
-          </p>
-
+        <div className="horizontal-divider"></div>
+        <div className="container d-grid gap-3">
+          <h2>
+            <b>{messages.GeneralInfoSection.H2Text.en}</b>
+          </h2>
           <div>
-            <p> {pia.initiativeDescription}</p>
+            <div className="row ">
+              <div className="col col-md-4">
+                <b>Drafter</b>
+              </div>
+              <div className="col col-md-4">
+                <b>Initiative Lead</b>
+              </div>
+              <div className="col col-md-4">
+                <b>Ministry Privacy Officer </b>
+              </div>
+            </div>
+            <div className="row">
+              <div className="col col-md-4">{pia.drafterName}</div>
+              <div className="col col-md-4">{pia.leadName}</div>
+              <div className="col col-md-4">{pia.mpoName}</div>
+            </div>
+            <div className="row">
+              <div className="col col-md-4">{pia.drafterTitle}</div>
+              <div className="col col-md-4">{pia.leadTitle}</div>
+              <div className="col col-md-4">{pia.mpoEmail}</div>
+            </div>
+            <div className="row">
+              <div className="col col-md-4">{pia.drafterEmail}</div>
+              <div className="col col-md-4">{pia.leadEmail}</div>
+            </div>
+          </div>
+          <div>
+            <div className="row">
+              <div className="col col-md-4">
+                <b>Ministry</b>
+              </div>
+              <div className="col col-md-4">
+                <b>Branch</b>
+              </div>
+            </div>
+            <div className="row">
+              <div className="col col-md-4">{piaMinistryFullName}</div>
+              <div className="col col-md-4">{pia.branch}</div>
+            </div>
           </div>
         </div>
-        <div>
-          <p>{messages.InitiativeScopeSection.H2Text.en}</p>
-
+        <div className="container pt-5 form__section">
+          <h2 className="pb-3">
+            <b>{messages.GeneralInfoSection.H2TextTwo.en}</b>
+          </h2>
           <div>
-            <p> {pia.initiativeScope}</p>
+            <h2 className="form__h2">
+              {messages.InitiativeDescriptionSection.en}
+            </h2>
+
+            <div>
+              <MDEditor preview="preview" value={pia.initiativeDescription} />
+            </div>
+          </div>
+          <div className="form__section">
+            <h2 className="form__h2">{messages.InitiativeScopeSection.en}</h2>
+
+            <div>
+              <MDEditor preview="preview" value={pia.initiativeScope} />
+            </div>
+          </div>
+          <div className="form__section">
+            <h2 className="pb-2 pt-3">
+              {messages.InitiativeDataElementsSection.en}
+            </h2>
+
+            <div>
+              <MDEditor preview="preview" value={pia.dataElementsInvolved} />
+            </div>
           </div>
         </div>
-        <div>
-          <p>{messages.InitiativeDataElementsSection.H2Text.en}</p>
-
+        <div className="container pt-5">
+          <h2>
+            <b>{messages.GeneralInfoSection.H2TextThree.en}</b>
+          </h2>
           <div>
-            <p> {pia.dataElementsInvolved}</p>
+            <h2 className="form__h2">{messages.InitiativePISection.en}</h2>
+
+            <div>
+              <p>{piOption}</p>
+            </div>
           </div>
-        </div>
-      </div>
-      <div className="container pt-5">
-        <h2 className="pb-3">
-          <b> {messages.GeneralInfoSection.H2TextThree.en}</b>
-        </h2>
-        <div>
-          <p>{messages.InitiativePISection.H2Text.en}</p>
-
-          <div>
-            <p> {pia.hasAddedPiToDataElements}</p>
-          </div>
-        </div>
-        <div>
-          <p>{messages.InitiativeRiskReductionSection.H2Text.en}</p>
-
-          <div>
-            <p> {pia.riskMitigation}</p>
+          <div className="form__section">
+            <h2 className="form__h2">
+              {messages.InitiativeRiskReductionSection.en}
+            </h2>
+            <div>
+              <MDEditor preview="preview" value={pia.riskMitigation} />
+            </div>
           </div>
         </div>
       </div>

--- a/src/frontend/src/pages/PIADetailPage/index.tsx
+++ b/src/frontend/src/pages/PIADetailPage/index.tsx
@@ -2,7 +2,7 @@ import {
   IPIAIntake,
   IPIAIntakeResponse,
 } from '../../types/interfaces/pia-intake.interface';
-import { faFileArrowDown } from '@fortawesome/free-solid-svg-icons';
+import { faArrowDown } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { dateToString } from '../../utils/date';
 import messages from './messages';
@@ -12,14 +12,6 @@ import { useEffect, useState } from 'react';
 import { HttpRequest } from '../../utils/http-request.util';
 import { API_ROUTES } from '../../constant/apiRoutes';
 import { routes } from '../../constant/routes';
-import Alert from '../../components/common/Alert';
-import MDEditor from '@uiw/react-md-editor';
-import { MinistryList, PIOptions } from '../../constant/constant';
-import {
-  FileDownload,
-  FileDownloadTypeEnum,
-} from '../../utils/file-download.util';
-import Spinner from '../../components/common/Spinner';
 
 const PIADetailPage = () => {
   // https://github.com/microsoft/TypeScript/issues/48949
@@ -28,11 +20,6 @@ const PIADetailPage = () => {
   const { id } = useParams();
   const navigate = useNavigate();
   const [pia, setPia] = useState<any>({});
-  const [fetchPiaError, setFetchPiaError] = useState('');
-  const [piaMinistryFullName, setPiaMinistryFullName] = useState('');
-  const [isDownloading, setIsDownloading] = useState(false);
-  const [downloadError, setDownloadError] = useState('');
-  const [piOption, setPIOption] = useState('');
   useEffect(() => {
     (async () => {
       try {
@@ -43,204 +30,132 @@ const PIADetailPage = () => {
           )
         ).data;
         setPia(result);
-        setPiaMinistryFullName(
-          MinistryList.filter((item) => item.value === pia.ministry)[0].label,
-        );
-        setPIOption(
-          pia.hasAddedPiToDataElements === true
-            ? PIOptions[0]
-            : pia.hasAddedPiToDataElements === false
-            ? PIOptions[1]
-            : PIOptions[2],
-        );
-      } catch (e) {
-        if (e instanceof Error && e.cause instanceof Error) {
-          const errorCode = e.cause.message as unknown as string;
-          if (errorCode === '404') {
-            win.location = routes.NOT_FOUND;
-          } else if (
-            errorCode === '401' ||
-            errorCode === '403' ||
-            errorCode === '410'
-          ) {
-            win.location = routes.NOT_AUTHORIZED;
-          } else {
-            setFetchPiaError('Something went wrong. Please try again.');
-            throw new Error('Fetch pia failed');
-          }
+      } catch (e: any) {
+        const errorCode: string = e.message.split(':')[1];
+        if (errorCode.includes('404')) {
+          win.location = routes.NOT_FOUND;
+        } else if (errorCode.includes('401') || errorCode.includes('403')) {
+          win.location = routes.NOT_AUTHORIZED;
+        } else {
+          throw new Error('Fetch pia failed');
         }
       }
     })();
-  }, [id, navigate, pia.hasAddedPiToDataElements, pia.ministry, win]);
+  }, [id, navigate, win]);
 
-  const handleAlertClose = () => {
-    setFetchPiaError('');
-    setDownloadError('');
-  };
-
-  const handleDownload = async () => {
-    setDownloadError('');
-
-    if (!id) {
-      console.error(
-        'Something went wrong. Result Id not available for download',
-      );
-      setDownloadError('Something went wrong. Please try again.');
-      return;
-    }
-
-    setIsDownloading(true);
-    try {
-      await FileDownload.download(
-        API_ROUTES.PIA_INTAKE_RESULT_DOWNLOAD.replace(':id', `${id}`),
-        FileDownloadTypeEnum.PDF,
-      );
-    } catch (e) {
-      setDownloadError('Something went wrong. Please try again.');
-    } finally {
-      setIsDownloading(false);
-    }
-  };
   return (
-    <div className="bcgovPageContainer background ">
-      <div className="container__padding-inline ppq-form-section form__container row">
-        {fetchPiaError && (
-          <Alert
-            type="danger"
-            message="Something went wrong. Please try again."
-            onClose={handleAlertClose}
-            className="mt-2"
-          />
-        )}
-        {downloadError && (
-          <Alert
-            type="danger"
-            message="Something went wrong. Please try again."
-            onClose={handleAlertClose}
-            className="mt-2"
-          />
-        )}
-        <div className="form__title">
-          <h1>{pia.title}</h1>
-          <button
-            className={`bcgovbtn bcgovbtn__primary ${
-              isDownloading ? 'opacity-50 pe-none' : ''
-            }`}
-            onClick={() => handleDownload()}
-          >
-            <FontAwesomeIcon icon={faFileArrowDown} />
-            {isDownloading && <Spinner />}
-          </button>
+    <div className="bcgovPageContainer results results-wrapper ppq-connect">
+      <div className="form__title">
+        <h1>{pia.title}</h1>
+        <a href="/pia-edit" className="bcgovbtn bcgovbtn__primary">
+          <FontAwesomeIcon icon={faArrowDown} />
+        </a>
+      </div>
+      <div>
+        <div className="row">
+          <div className="col col-md-4">Status</div>
+          <div className="col col-md-4">Submitted on</div>
+          <div className="col col-md-4">Last modified</div>
+        </div>
+        <div className="row">
+          <div className="col col-md-4">
+            {pia.status ? pia.status : 'Submitted'}
+          </div>
+          <div className="col col-md-4">{dateToString(pia.createdAt)}</div>
+          <div className="col col-md-4">{dateToString(pia.updatedAt)}</div>
+        </div>
+      </div>
+      <div className="horizontal-divider"></div>
+      <div className="container d-grid gap-3">
+        <h2>
+          <b>{messages.GeneralInfoSection.H2Text.en}</b>
+        </h2>
+        <div>
+          <div className="row ">
+            <div className="col col-md-4">
+              <b>Drafter</b>
+            </div>
+            <div className="col col-md-4">
+              <b>Initiative Lead</b>
+            </div>
+            <div className="col col-md-4">
+              <b>Ministry Privacy Officer </b>
+            </div>
+          </div>
+          <div className="row">
+            <div className="col col-md-4">{pia.drafterName}</div>
+            <div className="col col-md-4">{pia.leadName}</div>
+            <div className="col col-md-4">{pia.mpoName}</div>
+          </div>
+          <div className="row">
+            <div className="col col-md-4">{pia.drafterTitle}</div>
+            <div className="col col-md-4">{pia.leadTitle}</div>
+            <div className="col col-md-4">{pia.mpoEmail}</div>
+          </div>
+          <div className="row">
+            <div className="col col-md-4">{pia.drafterEmail}</div>
+            <div className="col col-md-4">{pia.leadEmail}</div>
+          </div>
         </div>
         <div>
           <div className="row">
-            <div className="col col-md-4">Status</div>
-            <div className="col col-md-4">Submitted on</div>
-            <div className="col col-md-4">Last modified</div>
+            <div className="col col-md-4">
+              <b>Ministry</b>
+            </div>
+            <div className="col col-md-4">
+              <b>Branch</b>
+            </div>
           </div>
           <div className="row">
-            <div className="col col-md-4">
-              {pia.status ? pia.status : 'Submitted'}
-            </div>
-            <div className="col col-md-4">{dateToString(pia.createdAt)}</div>
-            <div className="col col-md-4">{dateToString(pia.updatedAt)}</div>
+            <div className="col col-md-4">{pia.ministry}</div>
+            <div className="col col-md-4">{pia.branch}</div>
           </div>
         </div>
-        <div className="horizontal-divider"></div>
-        <div className="container d-grid gap-3">
-          <h2>
-            <b>{messages.GeneralInfoSection.H2Text.en}</b>
-          </h2>
+      </div>
+      <div className="container pt-5">
+        <h2 className="pb-3">
+          <b>{messages.GeneralInfoSection.H2TextTwo.en}</b>
+        </h2>
+        <div>
+          <p className="pb-1">
+            {messages.InitiativeDescriptionSection.H2Text.en}
+          </p>
+
           <div>
-            <div className="row ">
-              <div className="col col-md-4">
-                <b>Drafter</b>
-              </div>
-              <div className="col col-md-4">
-                <b>Initiative Lead</b>
-              </div>
-              <div className="col col-md-4">
-                <b>Ministry Privacy Officer </b>
-              </div>
-            </div>
-            <div className="row">
-              <div className="col col-md-4">{pia.drafterName}</div>
-              <div className="col col-md-4">{pia.leadName}</div>
-              <div className="col col-md-4">{pia.mpoName}</div>
-            </div>
-            <div className="row">
-              <div className="col col-md-4">{pia.drafterTitle}</div>
-              <div className="col col-md-4">{pia.leadTitle}</div>
-              <div className="col col-md-4">{pia.mpoEmail}</div>
-            </div>
-            <div className="row">
-              <div className="col col-md-4">{pia.drafterEmail}</div>
-              <div className="col col-md-4">{pia.leadEmail}</div>
-            </div>
-          </div>
-          <div>
-            <div className="row">
-              <div className="col col-md-4">
-                <b>Ministry</b>
-              </div>
-              <div className="col col-md-4">
-                <b>Branch</b>
-              </div>
-            </div>
-            <div className="row">
-              <div className="col col-md-4">{piaMinistryFullName}</div>
-              <div className="col col-md-4">{pia.branch}</div>
-            </div>
+            <p> {pia.initiativeDescription}</p>
           </div>
         </div>
-        <div className="container pt-5 form__section">
-          <h2 className="pb-3">
-            <b>{messages.GeneralInfoSection.H2TextTwo.en}</b>
-          </h2>
+        <div>
+          <p>{messages.InitiativeScopeSection.H2Text.en}</p>
+
           <div>
-            <h2 className="form__h2">
-              {messages.InitiativeDescriptionSection.en}
-            </h2>
-
-            <div>
-              <MDEditor preview="preview" value={pia.initiativeDescription} />
-            </div>
-          </div>
-          <div className="form__section">
-            <h2 className="form__h2">{messages.InitiativeScopeSection.en}</h2>
-
-            <div>
-              <MDEditor preview="preview" value={pia.initiativeScope} />
-            </div>
-          </div>
-          <div className="form__section">
-            <h2 className="pb-2 pt-3">
-              {messages.InitiativeDataElementsSection.en}
-            </h2>
-
-            <div>
-              <MDEditor preview="preview" value={pia.dataElementsInvolved} />
-            </div>
+            <p> {pia.initiativeScope}</p>
           </div>
         </div>
-        <div className="container pt-5">
-          <h2>
-            <b>{messages.GeneralInfoSection.H2TextThree.en}</b>
-          </h2>
-          <div>
-            <h2 className="form__h2">{messages.InitiativePISection.en}</h2>
+        <div>
+          <p>{messages.InitiativeDataElementsSection.H2Text.en}</p>
 
-            <div>
-              <p>{piOption}</p>
-            </div>
+          <div>
+            <p> {pia.dataElementsInvolved}</p>
           </div>
-          <div className="form__section">
-            <h2 className="form__h2">
-              {messages.InitiativeRiskReductionSection.en}
-            </h2>
-            <div>
-              <MDEditor preview="preview" value={pia.riskMitigation} />
-            </div>
+        </div>
+      </div>
+      <div className="container pt-5">
+        <h2 className="pb-3">
+          <b> {messages.GeneralInfoSection.H2TextThree.en}</b>
+        </h2>
+        <div>
+          <p>{messages.InitiativePISection.H2Text.en}</p>
+
+          <div>
+            <p> {pia.hasAddedPiToDataElements}</p>
+          </div>
+        </div>
+        <div>
+          <p>{messages.InitiativeRiskReductionSection.H2Text.en}</p>
+
+          <div>
+            <p> {pia.riskMitigation}</p>
           </div>
         </div>
       </div>

--- a/src/frontend/src/pages/PIADetailPage/index.tsx
+++ b/src/frontend/src/pages/PIADetailPage/index.tsx
@@ -199,7 +199,7 @@ const PIADetailPage = () => {
           </h2>
           <div>
             <h2 className="form__h2">
-              {messages.InitiativeDescriptionSection.en}
+              {messages.InitiativeDescriptionSection.H2Text.en}
             </h2>
 
             <div>
@@ -207,7 +207,9 @@ const PIADetailPage = () => {
             </div>
           </div>
           <div className="form__section">
-            <h2 className="form__h2">{messages.InitiativeScopeSection.en}</h2>
+            <h2 className="form__h2">
+              {messages.InitiativeScopeSection.H2Text.en}
+            </h2>
 
             <div>
               <MDEditor preview="preview" value={pia.initiativeScope} />
@@ -215,7 +217,7 @@ const PIADetailPage = () => {
           </div>
           <div className="form__section">
             <h2 className="pb-2 pt-3">
-              {messages.InitiativeDataElementsSection.en}
+              {messages.InitiativeDataElementsSection.H2Text.en}
             </h2>
 
             <div>
@@ -228,7 +230,9 @@ const PIADetailPage = () => {
             <b>{messages.GeneralInfoSection.H2TextThree.en}</b>
           </h2>
           <div>
-            <h2 className="form__h2">{messages.InitiativePISection.en}</h2>
+            <h2 className="form__h2">
+              {messages.InitiativePISection.H2Text.en}
+            </h2>
 
             <div>
               <p>{piOption}</p>
@@ -236,7 +240,7 @@ const PIADetailPage = () => {
           </div>
           <div className="form__section">
             <h2 className="form__h2">
-              {messages.InitiativeRiskReductionSection.en}
+              {messages.InitiativeRiskReductionSection.H2Text.en}
             </h2>
             <div>
               <MDEditor preview="preview" value={pia.riskMitigation} />

--- a/src/frontend/src/pages/PIADetailPage/messages.ts
+++ b/src/frontend/src/pages/PIADetailPage/messages.ts
@@ -11,19 +11,29 @@ export default {
     },
   },
   InitiativeDescriptionSection: {
-    en: `What is the initiative?`,
+    H2Text: {
+      en: `What is the initiative?`,
+    },
   },
   InitiativeScopeSection: {
-    en: `What is the scope of the PIA?`,
+    H2Text: {
+      en: `What is the scope of the PIA?`,
+    },
   },
   InitiativeDataElementsSection: {
-    en: `What are the data or information elements involved in your initiative?`,
+    H2Text: {
+      en: `What are the data or information elements involved in your initiative?`,
+    },
   },
   InitiativePISection: {
-    en: `Did you list personal information in question 3?`,
+    H2Text: {
+      en: `Did you list personal information in question 3?`,
+    },
   },
   InitiativeRiskReductionSection: {
-    en: `How will you reduce the risk of unintentionally collecting personal 
+    H2Text: {
+      en: `How will you reduce the risk of unintentionally collecting personal 
         information?`,
+    },
   },
 };

--- a/src/frontend/src/pages/PIAIntakeForm/index.tsx
+++ b/src/frontend/src/pages/PIAIntakeForm/index.tsx
@@ -3,7 +3,7 @@ import InputText from '../../components/common/InputText/InputText';
 import { MinistryList, PIOptions } from '../../constant/constant';
 import Messages from './messages';
 import MDEditor from '@uiw/react-md-editor';
-import { ChangeEvent, useState } from 'react';
+import { ChangeEvent, MouseEvent, useState } from 'react';
 import Alert from '../../components/common/Alert';
 import { HttpRequest } from '../../utils/http-request.util';
 import { API_ROUTES } from '../../constant/apiRoutes';
@@ -11,12 +11,13 @@ import { useNavigate } from 'react-router-dom';
 import { IPIAIntake } from '../../types/interfaces/pia-intake.interface';
 import { IPIAResult } from '../../types/interfaces/pia-result.interface';
 import { routes } from '../../constant/routes';
+import Modal from '../../components/common/Modal';
 
 const PIAIntakeFormPage = () => {
   const navigate = useNavigate();
 
   //
-  // Local State
+  // Form State
   //
   const [message, setMessage] = useState<string>('');
   const [title, setTitle] = useState<string>('');
@@ -40,9 +41,52 @@ const PIAIntakeFormPage = () => {
   const [riskMitigation, setRiskMitigation] = useState<string>();
 
   //
+  // Modal State
+  //
+  const [showModal, setShowModal] = useState<boolean>(false);
+  const [modalConfirmLabel, setModalConfirmLabel] = useState<string>('');
+  const [modalCancelLabel, setModalCancelLabel] = useState<string>('');
+  const [modalTitleText, setModalTitleText] = useState<string>('');
+  const [modalParagraph, setModalParagraph] = useState<string>('');
+
+  //
   // Event Handlers
   //
+  const handleShowModal = (modalType: string) => {
+    switch (modalType) {
+      case 'cancel':
+        setModalConfirmLabel(Messages.Modal.Cancel.ConfirmLabel.en);
+        setModalCancelLabel(Messages.Modal.Cancel.CancelLabel.en);
+        setModalTitleText(Messages.Modal.Cancel.TitleText.en);
+        setModalParagraph(Messages.Modal.Cancel.ParagraphText.en);
+        break;
+      case 'save':
+        setModalConfirmLabel(Messages.Modal.Save.ConfirmLabel.en);
+        setModalCancelLabel(Messages.Modal.Save.CancelLabel.en);
+        setModalTitleText(Messages.Modal.Save.TitleText.en);
+        setModalParagraph(Messages.Modal.Save.ParagraphText.en);
+        break;
+      default:
+        break;
+    }
+    setShowModal(true);
+  };
+
+  const handleModalClose = () => {
+    setShowModal(false);
+    navigate('/pia-list');
+  };
+
+  const handleModalCancel = () => {
+    setShowModal(false);
+  };
+
+  const handleSaveChanges = () => {
+    handleShowModal('save');
+  };
+
   const handleBackClick = () => {
+    handleShowModal('cancel');
     navigate(-1);
   };
 
@@ -362,12 +406,21 @@ const PIAIntakeFormPage = () => {
             >
               Back
             </button>
-            <button
-              type="submit"
-              className="bcgovbtn bcgovbtn__primary btn-next"
-            >
-              Submit
-            </button>
+            <div className="form__button-group">
+              <button
+                type="button"
+                className="bcgovbtn bcgovbtn__secondary"
+                onClick={handleSaveChanges}
+              >
+                Save changes
+              </button>
+              <button
+                type="submit"
+                className="bcgovbtn bcgovbtn__primary btn-next"
+              >
+                Submit
+              </button>
+            </div>
           </div>
           {message && (
             <Alert
@@ -379,6 +432,16 @@ const PIAIntakeFormPage = () => {
           )}
         </form>
       </section>
+      <Modal
+        confirmLabel={modalConfirmLabel}
+        cancelLabel={modalCancelLabel}
+        titleText={modalTitleText}
+        show={showModal}
+        handleClose={handleModalClose}
+        handleCancel={handleModalCancel}
+      >
+        <p className="modal-text">{modalParagraph}</p>
+      </Modal>
     </div>
   );
 };

--- a/src/frontend/src/pages/PIAIntakeForm/messages.ts
+++ b/src/frontend/src/pages/PIAIntakeForm/messages.ts
@@ -72,4 +72,35 @@ export default {
       incident or privacy breach. `,
     },
   },
+  Modal: {
+    Save: {
+      ConfirmLabel: {
+        en: `Save`,
+      },
+      CancelLabel: {
+        en: `Don't save`,
+      },
+      TitleText: {
+        en: `Do you want to save this PIA?`,
+      },
+      ParagraphText: {
+        en: `Only you will be able to view the saved version and you can return at any 
+        time to make further changes.`,
+      },
+    },
+    Cancel: {
+      ConfirmLabel: {
+        en: `Leave`,
+      },
+      CancelLabel: {
+        en: `Cancel`,
+      },
+      TitleText: {
+        en: `Leave without saving?`,
+      },
+      ParagraphText: {
+        en: `Any changes you've made will be lost if you leave this page.`,
+      },
+    },
+  },
 };

--- a/src/frontend/src/sass/_form.scss
+++ b/src/frontend/src/sass/_form.scss
@@ -40,6 +40,11 @@
   justify-content: space-between;
 }
 
+.form__button-group {
+  display: flex;
+  gap: 0.5em;
+}
+
 .helper-text__link-icon {
   margin-left: 0.3em;
 }


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- Implements save modal for PIA intake
- Tweaks existing modal component to allow for reversed button order as the 'sign out' modal's buttons are opposite of iteration 4 modals

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

## How Has This Been Tested?

Visual assertion of modals based on which button triggers the modal.

## Development Dependency Working Agreement
- [x] My code DOES NOT include the importing of new dependencies into the DPIA ecosystem
- [ ] My code DOES include the importing of new dependencies into the DPIA ecosystem
**If new dependencies are being introduced to the DPIA ecosystem:**
- [ ] The functionality of the dependency drastically reduces code complexity and makes my changes more easily maintainable and readible 
- [ ] The dependency being introduced does not contain multiple layers of nested dependencies introducing maintainability complexity to the DPIA ecosystem

## Frontend Development Changes
- [ ] N/A
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to project documentation or diagrams that reflect my changes
- [ ] New and existing unit tests pass locally with my changes
- [x] My code follows Airbnb React Style Guidelines

## API Development Changes
- [x] N/A
- [ ] I have performed a self-review of my own code
- [ ] My code follows standards and practices outlined in the BC Government API Development Guidelines
- [ ] New and existing unit tests pass locally with my changes
- [ ] My changes includes Swagger documentation updates that reflect the changes I am introducing

## Definition of Done

![Definition of Done](https://raw.githubusercontent.com/bcgov/cirmo-dpia/main/.github/assets/DoD.jpg)
