### PR TITLE
UTOPIA-607: [Front End] Handle page refresh

### DIFF
--- a/src/frontend/src/constant/constant.ts
+++ b/src/frontend/src/constant/constant.ts
@@ -207,3 +207,10 @@ export const ReviewTypes = [
 export const PIOptions = ['Yes', 'No', "I'm not sure"];
 
 export const startDateOptions = ['Yes', 'No'];
+
+export enum PiaStatuses {
+  INCOMPLETE = 'INCOMPLETE',
+  EDIT_IN_PROGRESS = 'EDIT_IN_PROGRESS',
+  MPO_REVIEW = 'MPO_REVIEW',
+  PCT_REVIEW = 'PCT_REVIEW',
+}

--- a/src/frontend/src/pages/PIAIntakeForm/index.tsx
+++ b/src/frontend/src/pages/PIAIntakeForm/index.tsx
@@ -44,11 +44,11 @@ const PIAIntakeFormPage = () => {
   //
   // Modal State
   //
-  const [showModal, setShowModal] = useState<boolean>(false);
-  const [modalConfirmLabel, setModalConfirmLabel] = useState<string>('');
-  const [modalCancelLabel, setModalCancelLabel] = useState<string>('');
-  const [modalTitleText, setModalTitleText] = useState<string>('');
-  const [modalParagraph, setModalParagraph] = useState<string>('');
+  const [showPiaModal, setShowPiaModal] = useState<boolean>(false);
+  const [piaModalConfirmLabel, setPiaModalConfirmLabel] = useState<string>('');
+  const [piaModalCancelLabel, setPiaModalCancelLabel] = useState<string>('');
+  const [piaModalTitleText, setPiaModalTitleText] = useState<string>('');
+  const [piaModalParagraph, setPiaModalParagraph] = useState<string>('');
 
   //
   // Event Handlers
@@ -56,30 +56,30 @@ const PIAIntakeFormPage = () => {
   const handleShowModal = (modalType: string) => {
     switch (modalType) {
       case 'cancel':
-        setModalConfirmLabel(Messages.Modal.Cancel.ConfirmLabel.en);
-        setModalCancelLabel(Messages.Modal.Cancel.CancelLabel.en);
-        setModalTitleText(Messages.Modal.Cancel.TitleText.en);
-        setModalParagraph(Messages.Modal.Cancel.ParagraphText.en);
+        setPiaModalConfirmLabel(Messages.Modal.Cancel.ConfirmLabel.en);
+        setPiaModalCancelLabel(Messages.Modal.Cancel.CancelLabel.en);
+        setPiaModalTitleText(Messages.Modal.Cancel.TitleText.en);
+        setPiaModalParagraph(Messages.Modal.Cancel.ParagraphText.en);
         break;
       case 'save':
-        setModalConfirmLabel(Messages.Modal.Save.ConfirmLabel.en);
-        setModalCancelLabel(Messages.Modal.Save.CancelLabel.en);
-        setModalTitleText(Messages.Modal.Save.TitleText.en);
-        setModalParagraph(Messages.Modal.Save.ParagraphText.en);
+        setPiaModalConfirmLabel(Messages.Modal.Save.ConfirmLabel.en);
+        setPiaModalCancelLabel(Messages.Modal.Save.CancelLabel.en);
+        setPiaModalTitleText(Messages.Modal.Save.TitleText.en);
+        setPiaModalParagraph(Messages.Modal.Save.ParagraphText.en);
         break;
       default:
         break;
     }
-    setShowModal(true);
+    setShowPiaModal(true);
   };
 
   const handleModalClose = () => {
-    setShowModal(false);
+    setShowPiaModal(false);
     navigate('/pia-list');
   };
 
   const handleModalCancel = () => {
-    setShowModal(false);
+    setShowPiaModal(false);
   };
 
   const handleSaveChanges = () => {
@@ -470,14 +470,14 @@ const PIAIntakeFormPage = () => {
         </form>
       </section>
       <Modal
-        confirmLabel={modalConfirmLabel}
-        cancelLabel={modalCancelLabel}
-        titleText={modalTitleText}
-        show={showModal}
+        confirmLabel={piaModalConfirmLabel}
+        cancelLabel={piaModalCancelLabel}
+        titleText={piaModalTitleText}
+        show={showPiaModal}
         handleClose={handleModalClose}
         handleCancel={handleModalCancel}
       >
-        <p className="modal-text">{modalParagraph}</p>
+        <p className="modal-text">{piaModalParagraph}</p>
       </Modal>
     </div>
   );

--- a/src/frontend/src/pages/PIAIntakeForm/index.tsx
+++ b/src/frontend/src/pages/PIAIntakeForm/index.tsx
@@ -39,7 +39,7 @@ const PIAIntakeFormPage = () => {
     boolean | null
   >(true);
   const [riskMitigation, setRiskMitigation] = useState<string>();
-  const [status, setStatus] = useState<string>('');
+  const [status, setStatus] = useState<string>('INCOMPLETE');
 
   //
   // Modal State

--- a/src/frontend/src/pages/PIAIntakeForm/index.tsx
+++ b/src/frontend/src/pages/PIAIntakeForm/index.tsx
@@ -88,7 +88,7 @@ const PIAIntakeFormPage = () => {
 
   const alertUserLeave = (e: any) => {
     e.preventDefault();
-    e.returnValue = true;
+    e.defaultPrevented = true;
   };
 
   const handleBackClick = () => {

--- a/src/frontend/src/pages/PIAIntakeForm/index.tsx
+++ b/src/frontend/src/pages/PIAIntakeForm/index.tsx
@@ -88,6 +88,21 @@ const PIAIntakeFormPage = () => {
 
   const alertUserLeave = (e: any) => {
     e.preventDefault();
+
+    /* 
+      For cross-browser support
+      
+      This function uses e.returnValue, which has been deprecated for 9+ years.
+      The reason for this usage is to support Chrome which only behaves as expected when using this value.
+
+      Below are a couple of references on this topic.
+
+      References:
+      - https://developer.mozilla.org/en-US/docs/Web/API/Event/returnValue
+      - https://contest-server.cs.uchicago.edu/ref/JavaScript/developer.mozilla.org/en-US/docs/Web/API/Event/returnValue.html
+    */
+    e.returnValue = true;
+
     e.defaultPrevented = true;
   };
 

--- a/src/frontend/src/pages/PIAIntakeForm/index.tsx
+++ b/src/frontend/src/pages/PIAIntakeForm/index.tsx
@@ -3,7 +3,7 @@ import InputText from '../../components/common/InputText/InputText';
 import { MinistryList, PIOptions } from '../../constant/constant';
 import Messages from './messages';
 import MDEditor from '@uiw/react-md-editor';
-import { ChangeEvent, MouseEvent, useState } from 'react';
+import { ChangeEvent, useEffect, useState } from 'react';
 import Alert from '../../components/common/Alert';
 import { HttpRequest } from '../../utils/http-request.util';
 import { API_ROUTES } from '../../constant/apiRoutes';
@@ -39,6 +39,7 @@ const PIAIntakeFormPage = () => {
     boolean | null
   >(true);
   const [riskMitigation, setRiskMitigation] = useState<string>();
+  const [status, setStatus] = useState<string>('');
 
   //
   // Modal State
@@ -83,6 +84,11 @@ const PIAIntakeFormPage = () => {
 
   const handleSaveChanges = () => {
     handleShowModal('save');
+  };
+
+  const alertUserLeave = (e: any) => {
+    e.preventDefault();
+    e.returnValue = true;
   };
 
   const handleBackClick = () => {
@@ -159,6 +165,25 @@ const PIAIntakeFormPage = () => {
     setRiskMitigation(newRiskMitigation);
   };
 
+  const handleStatusChange = (piaStatus: any) => {
+    switch (piaStatus) {
+      case 'incomplete':
+        setStatus('INCOMPLETE');
+        break;
+      case 'edit-in-progress':
+        setStatus('EDIT_IN_PROGRESS');
+        break;
+      case 'mpo-review':
+        setStatus('MPO_REVIEW');
+        break;
+      case 'pct-review':
+        setStatus('PCT_REVIEW');
+        break;
+      default:
+        break;
+    }
+  };
+
   //
   // Form Submission Handler
   //
@@ -181,6 +206,7 @@ const PIAIntakeFormPage = () => {
       dataElementsInvolved: dataElementsInvolved,
       hasAddedPiToDataElements: hasAddedPiToDataElements,
       riskMitigation: riskMitigation,
+      status: status,
     };
     try {
       const res = await HttpRequest.post<IPIAResult>(
@@ -196,12 +222,23 @@ const PIAIntakeFormPage = () => {
     }
   };
 
+  useEffect(() => {
+    window.addEventListener('beforeunload', alertUserLeave);
+    return () => {
+      window.removeEventListener('beforeunload', alertUserLeave);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   return (
     <div className="bcgovPageContainer background background__form">
       <section className="ppq-form-section form__container">
         <form
           className="container__padding-inline"
-          onSubmit={(e) => handleSubmit(e)}
+          onSubmit={(e) => {
+            handleStatusChange('mpo-review');
+            handleSubmit(e);
+          }}
         >
           <div className="form__header">
             <h1>{Messages.PiaIntakeHeader.H1Text.en}</h1>

--- a/src/frontend/src/pages/PIAIntakeForm/index.tsx
+++ b/src/frontend/src/pages/PIAIntakeForm/index.tsx
@@ -1,6 +1,6 @@
 import Dropdown from '../../components/common/Dropdown';
 import InputText from '../../components/common/InputText/InputText';
-import { MinistryList, PIOptions } from '../../constant/constant';
+import { MinistryList, PIOptions, PiaStatuses } from '../../constant/constant';
 import Messages from './messages';
 import MDEditor from '@uiw/react-md-editor';
 import { ChangeEvent, useEffect, useState } from 'react';
@@ -39,7 +39,7 @@ const PIAIntakeFormPage = () => {
     boolean | null
   >(true);
   const [riskMitigation, setRiskMitigation] = useState<string>();
-  const [status, setStatus] = useState<string>('INCOMPLETE');
+  const [status, setStatus] = useState<string>(PiaStatuses.INCOMPLETE);
 
   //
   // Modal State
@@ -236,7 +236,7 @@ const PIAIntakeFormPage = () => {
         <form
           className="container__padding-inline"
           onSubmit={(e) => {
-            handleStatusChange('mpo-review');
+            handleStatusChange(PiaStatuses.MPO_REVIEW);
             handleSubmit(e);
           }}
         >

--- a/src/frontend/src/sass/index.scss
+++ b/src/frontend/src/sass/index.scss
@@ -25,11 +25,6 @@ a:hover {
   text-decoration: underline;
 }
 
-h1 {
-  font-size: 3.2em;
-  line-height: 1.1;
-}
-
 @media (prefers-color-scheme: light) {
   :root {
     color: #213547;


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- Adds alert for when user tries to refresh or navigate away from unsaved/unsubmitted form
- Adds status to http request body for pia intake

The alertUserLeave function uses `e.returnValue`, which has been deprecated for 9+ years. The reason for this usage is to support Chrome which only behaves as expected when using this value.

Below are a couple of references on this topic.

### References
- https://developer.mozilla.org/en-US/docs/Web/API/Event/returnValue
- https://contest-server.cs.uchicago.edu/ref/JavaScript/developer.mozilla.org/en-US/docs/Web/API/Event/returnValue.html

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Development Dependency Working Agreement
- [x] My code DOES NOT include the importing of new dependencies into the DPIA ecosystem
- [ ] My code DOES include the importing of new dependencies into the DPIA ecosystem
**If new dependencies are being introduced to the DPIA ecosystem:**
- [ ] The functionality of the dependency drastically reduces code complexity and makes my changes more easily maintainable and readible 
- [ ] The dependency being introduced does not contain multiple layers of nested dependencies introducing maintainability complexity to the DPIA ecosystem

## Frontend Development Changes
- [ ] N/A
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to project documentation or diagrams that reflect my changes
- [ ] New and existing unit tests pass locally with my changes
- [x] My code follows Airbnb React Style Guidelines

## API Development Changes
- [x] N/A
- [ ] I have performed a self-review of my own code
- [ ] My code follows standards and practices outlined in the BC Government API Development Guidelines
- [ ] New and existing unit tests pass locally with my changes
- [ ] My changes includes Swagger documentation updates that reflect the changes I am introducing

## Definition of Done

![Definition of Done](https://raw.githubusercontent.com/bcgov/cirmo-dpia/main/.github/assets/DoD.jpg)
