### PR TITLE
UTOPIA-666: [Frontend] Fix PIA Leave Page Warning

### DIFF
--- a/src/frontend/src/pages/PIAIntakeForm/index.tsx
+++ b/src/frontend/src/pages/PIAIntakeForm/index.tsx
@@ -77,6 +77,7 @@ const PIAIntakeFormPage = () => {
         setPiaModalCancelLabel(Messages.Modal.Cancel.CancelLabel.en);
         setPiaModalTitleText(Messages.Modal.Cancel.TitleText.en);
         setPiaModalParagraph(Messages.Modal.Cancel.ParagraphText.en);
+        setPiaModalButtonValue('cancel');
         break;
       case 'save':
         setPiaModalConfirmLabel(Messages.Modal.Save.ConfirmLabel.en);
@@ -144,6 +145,12 @@ const PIAIntakeFormPage = () => {
         navigate(routes.PIA_INTAKE_RESULT, {
           state: { result: res },
         });
+      } else if (buttonValue === 'cancel') {
+        if (pia?.id) {
+          navigate(`/pia/intake/${pia.id}/${pia.title}`);
+        } else {
+          navigate(-1);
+        }
       } else {
         if (pia?.id) {
           await HttpRequest.patch<IPIAResult>(
@@ -197,11 +204,6 @@ const PIAIntakeFormPage = () => {
 
   const handleBackClick = () => {
     handleShowModal('cancel');
-    if (pia?.id) {
-      navigate(`/pia/intake/${pia.id}/${pia.title}`);
-    } else {
-      navigate(-1);
-    }
   };
 
   const handleTitleChange = (newTitle: any) => {
@@ -305,7 +307,6 @@ const PIAIntakeFormPage = () => {
     return () => {
       window.removeEventListener('beforeunload', alertUserLeave);
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   return (


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- Fixes the lack of warning for users leaving the PIA Intake page (edit or new) using the 'Back' button at the bottom of the PIA Intake form

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

## How Has This Been Tested?

Clicked the 'Back' button on the PIA Intake form for both new and existing PIAs

## Development Dependency Working Agreement
- [x] My code DOES NOT include the importing of new dependencies into the DPIA ecosystem
- [ ] My code DOES include the importing of new dependencies into the DPIA ecosystem
**If new dependencies are being introduced to the DPIA ecosystem:**
- [ ] The functionality of the dependency drastically reduces code complexity and makes my changes more easily maintainable and readible 
- [ ] The dependency being introduced does not contain multiple layers of nested dependencies introducing maintainability complexity to the DPIA ecosystem

## Frontend Development Changes
- [ ] N/A
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to project documentation or diagrams that reflect my changes
- [ ] New and existing unit tests pass locally with my changes
- [x] My code follows Airbnb React Style Guidelines

## API Development Changes
- [x] N/A
- [ ] I have performed a self-review of my own code
- [ ] My code follows standards and practices outlined in the BC Government API Development Guidelines
- [ ] New and existing unit tests pass locally with my changes
- [ ] My changes includes Swagger documentation updates that reflect the changes I am introducing

## Definition of Done

![Definition of Done](https://raw.githubusercontent.com/bcgov/cirmo-dpia/main/.github/assets/DoD.jpg)
