### PR TITLE
[UTOPIA-735] PDF breaking fix for partial save + pdf should not contain 'N/A'

### DIFF
--- a/src/backend/src/modules/pia-intake/pia-intake.service.ts
+++ b/src/backend/src/modules/pia-intake/pia-intake.service.ts
@@ -302,15 +302,19 @@ export class PiaIntakeService {
       ...piaIntakeForm,
       ...{
         updatedAt: shortDate(piaIntakeForm.createdAt),
-        ministry: ministry || 'N/A',
-        initiativeDescription: marked.parse(
-          piaIntakeForm.initiativeDescription,
-        ),
-        initiativeScope: marked.parse(piaIntakeForm.initiativeScope),
-        dataElementsInvolved: marked.parse(piaIntakeForm.dataElementsInvolved),
+        ministry: ministry || '',
+        initiativeDescription: piaIntakeForm.initiativeDescription
+          ? marked.parse(piaIntakeForm.initiativeDescription)
+          : '',
+        initiativeScope: piaIntakeForm.initiativeScope
+          ? marked.parse(piaIntakeForm.initiativeScope)
+          : '',
+        dataElementsInvolved: piaIntakeForm.dataElementsInvolved
+          ? marked.parse(piaIntakeForm.dataElementsInvolved)
+          : '',
         riskMitigation: piaIntakeForm.riskMitigation
           ? marked.parse(piaIntakeForm.riskMitigation)
-          : null,
+          : '',
       },
     };
 

--- a/src/backend/src/modules/ppq/ppq.service.ts
+++ b/src/backend/src/modules/ppq/ppq.service.ts
@@ -63,13 +63,15 @@ export class PpqService {
       ...ppqForm,
       ...{
         updatedAt: shortDate(ppqForm.createdAt),
-        ministry: ministry || 'N/A',
-        piaType: piaType || 'N/A',
+        ministry: ministry || '',
+        piaType: piaType || '',
         delegatedReviewType: delegatedReviewType,
         proposedStartDate: ppqForm.proposedStartDate
           ? shortDate(ppqForm.proposedStartDate)
-          : 'N/A',
-        description: marked.parse(ppqForm.description),
+          : '',
+        description: ppqForm.description
+          ? marked.parse(ppqForm.description)
+          : '',
         otherFactors,
       },
     };

--- a/src/backend/src/modules/ppq/templates/ppq-result.pug
+++ b/src/backend/src/modules/ppq/templates/ppq-result.pug
@@ -37,9 +37,7 @@ div(style='padding-left: 5px; color: #444444')
 
       div(style=`${field_gap_style}`)
         div(style=`${key_style}`) Involves
-        if otherFactors.length === 0
-          div N/A
-        else 
+        if otherFactors.length !== 0
           ul
             each factor in otherFactors
               li #{factor}


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- partial saved data does not break PIA-intake pdf download
- removed N/A from all PDF - not the right terminology

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

## How Has This Been Tested?

Generating PDF from the app

## Development Dependency Working Agreement
- [x] My code DOES NOT include the importing of new dependencies into the DPIA ecosystem
- [ ] My code DOES include the importing of new dependencies into the DPIA ecosystem
**If new dependencies are being introduced to the DPIA ecosystem:**
- [ ] The functionality of the dependency drastically reduces code complexity and makes my changes more easily maintainable and readible 
- [ ] The dependency being introduced does not contain multiple layers of nested dependencies introducing maintainability complexity to the DPIA ecosystem

## Frontend Development Changes
- [x] N/A
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to project documentation or diagrams that reflect my changes
- [ ] New and existing unit tests pass locally with my changes
- [ ] My code follows Airbnb React Style Guidelines

## API Development Changes
- [ ] N/A
- [x] I have performed a self-review of my own code
- [x] My code follows standards and practices outlined in the BC Government API Development Guidelines
- [x] New and existing unit tests pass locally with my changes
- [ ] My changes includes Swagger documentation updates that reflect the changes I am introducing

## Definition of Done

![Definition of Done](https://raw.githubusercontent.com/bcgov/cirmo-dpia/main/.github/assets/DoD.jpg)
