### PR TITLE
[UTOPIA-750] [Frontend] Failure popup on auto-save fail

### DIFF
--- a/src/frontend/src/pages/PIAIntakeForm/index.tsx
+++ b/src/frontend/src/pages/PIAIntakeForm/index.tsx
@@ -44,6 +44,8 @@ const PIAIntakeFormPage = () => {
   const [isFirstSave, setIsFirstSave] = useState<boolean>(true);
 
   const [isConflict, setIsConflict] = useState<boolean>(false);
+  const [isAutoSaveFailedPopupShown, setIsAutoSaveFailedPopupShown] =
+    useState<boolean>(false);
 
   const [lastSaveAlertInfo, setLastSaveAlertInfo] =
     useState<ILastSaveAlterInfo>({
@@ -112,7 +114,18 @@ const PIAIntakeFormPage = () => {
             getShortTime(pia?.updatedAt),
           ),
         );
-        setPiaModalButtonValue('conflict');
+        setPiaModalButtonValue(modalType);
+        break;
+      case 'autoSaveFailed':
+        setPiaModalConfirmLabel(Messages.Modal.AutoSaveFailed.ConfirmLabel.en);
+        setPiaModalTitleText(Messages.Modal.AutoSaveFailed.TitleText.en);
+        setPiaModalParagraph(
+          Messages.Modal.AutoSaveFailed.ParagraphText.en.replace(
+            '${time}',
+            getShortTime(pia?.updatedAt),
+          ),
+        );
+        setPiaModalButtonValue(modalType);
         break;
       default:
         break;
@@ -173,6 +186,10 @@ const PIAIntakeFormPage = () => {
 
     setPia(updatedPia);
 
+    // reset flags after successful save
+    setIsAutoSaveFailedPopupShown(false);
+    setIsConflict(false);
+
     return updatedPia;
   };
 
@@ -196,6 +213,8 @@ const PIAIntakeFormPage = () => {
           navigate(-1);
         }
       } else if (buttonValue === 'conflict') {
+        // noop
+      } else if (buttonValue === 'autoSaveFailed') {
         // noop
       } else {
         const updatedPia = await upsertAndUpdatePia();
@@ -307,6 +326,9 @@ const PIAIntakeFormPage = () => {
         if (e?.cause?.message === '409') {
           setIsConflict(true);
           handleShowModal('conflict');
+        } else if (!isAutoSaveFailedPopupShown) {
+          handleShowModal('autoSaveFailed');
+          setIsAutoSaveFailedPopupShown(true);
         }
       }
     };

--- a/src/frontend/src/pages/PIAIntakeForm/messages.ts
+++ b/src/frontend/src/pages/PIAIntakeForm/messages.ts
@@ -130,6 +130,17 @@ export default {
         en: `Your PIA status will be changed to MPO review. Your MPO will be notified that your edits are complete and your PIA is ready for review.`,
       },
     },
+    AutoSaveFailed: {
+      ConfirmLabel: {
+        en: 'Okay',
+      },
+      TitleText: {
+        en: 'Auto-save failed',
+      },
+      ParagraphText: {
+        en: 'This document was last saved at ${time}. Before you leave the page, ensure you capture any unsaved work you don’t want to lose. Any unsaved changes will be lost.',
+      },
+    },
     Conflict: {
       ConfirmLabel: {
         en: 'Okay',


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- Failure popup on auto-save fail

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

## How Has This Been Tested?

Go offline and makes changes to the app; Come back online to reflect auto-save happens; and then go back offline and make change to see the popup appears again

## Development Dependency Working Agreement
- [x] My code DOES NOT include the importing of new dependencies into the DPIA ecosystem
- [ ] My code DOES include the importing of new dependencies into the DPIA ecosystem
**If new dependencies are being introduced to the DPIA ecosystem:**
- [ ] The functionality of the dependency drastically reduces code complexity and makes my changes more easily maintainable and readible 
- [ ] The dependency being introduced does not contain multiple layers of nested dependencies introducing maintainability complexity to the DPIA ecosystem

## Frontend Development Changes
- [ ] N/A
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to project documentation or diagrams that reflect my changes
- [ ] New and existing unit tests pass locally with my changes
- [x] My code follows Airbnb React Style Guidelines

## API Development Changes
- [x] N/A
- [ ] I have performed a self-review of my own code
- [ ] My code follows standards and practices outlined in the BC Government API Development Guidelines
- [ ] New and existing unit tests pass locally with my changes
- [ ] My changes includes Swagger documentation updates that reflect the changes I am introducing

## Definition of Done

![Definition of Done](https://raw.githubusercontent.com/bcgov/cirmo-dpia/main/.github/assets/DoD.jpg)
