### PR TITLE
[UTOPIA-528] Updated `proposedStartDate` in PPQ to date string instead of Timestamp

### DIFF
--- a/src/backend/src/common/validators/date-string.validator.ts
+++ b/src/backend/src/common/validators/date-string.validator.ts
@@ -1,0 +1,39 @@
+import {
+  ValidatorConstraint,
+  ValidatorConstraintInterface,
+} from '@nestjs/class-validator';
+
+// Custom Date String Validator for the format - YYYY/MM/DD
+// Reason for custom - @ISO8601/@DateString - validates for hyphen(-) separated dates; which may include Time as well. This would have required additional Transformation
+@ValidatorConstraint({ name: 'dateString', async: false })
+export class DateStringValidator implements ValidatorConstraintInterface {
+  validate(dateString: string) {
+    if (!dateString) return false;
+
+    // First check for the pattern
+    if (!/^\d{4}\/\d{2}\/\d{2}$/.test(dateString)) return false;
+
+    // Parse the date parts to integers
+    const parts = dateString.split('/');
+    const day = parseInt(parts[2], 10);
+    const month = parseInt(parts[1], 10);
+    const year = parseInt(parts[0], 10);
+
+    // Check the ranges of month and year
+    if (year < 1000 || year > 3000 || month == 0 || month > 12) return false;
+
+    const monthLength = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+
+    // Adjust for leap years
+    if (year % 400 == 0 || (year % 100 != 0 && year % 4 == 0))
+      monthLength[1] = 29;
+
+    // Check the range of the day
+    return day > 0 && day <= monthLength[month - 1];
+  }
+
+  defaultMessage({ property }) {
+    // here you can provide default error message if validation failed
+    return `${property} must be a valid date in YYYY/MM/DD format `;
+  }
+}

--- a/src/backend/src/migrations/1675472710074-ppq-propose-date-timestamp-to-date-string.ts
+++ b/src/backend/src/migrations/1675472710074-ppq-propose-date-timestamp-to-date-string.ts
@@ -1,0 +1,39 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class PpqProposeDateTimestampToDateString1675472710074
+  implements MigrationInterface
+{
+  name = 'ppqProposeDateTimestampToDateString1675472710074';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // create a temporary colum to store existing proposed_start_date data
+    await queryRunner.query(
+      `ALTER TABLE "ppq" ADD "proposed_start_date_temp" character varying`,
+    );
+
+    // move proposed_start_date date to proposed_start_date_temp
+    await queryRunner.query(
+      `UPDATE "ppq" SET "proposed_start_date_temp" = TO_CHAR(proposed_start_date, 'yyyy/mm/dd') where proposed_start_date_temp IS NULL`,
+    );
+
+    // delete proposed_start_date column to remove extra erroneous time information
+    await queryRunner.query(
+      `ALTER TABLE "ppq" DROP COLUMN "proposed_start_date"`,
+    );
+
+    // rename proposed_start_date_temp to proposed_start_date
+    await queryRunner.query(
+      `ALTER TABLE "ppq" RENAME COLUMN "proposed_start_date_temp" TO "proposed_start_date"`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    // CAUTION: Running down won't bring the lost data back
+    // if migration is reverted, data will still be lost
+
+    // bring back the deleted proposed_start_date timestamp
+    await queryRunner.query(
+      `ALTER TABLE "ppq" ADD "proposed_start_date" TIMESTAMP WITH TIME ZONE`,
+    );
+  }
+}

--- a/src/backend/src/modules/ppq/dto/ppq-post.dto.ts
+++ b/src/backend/src/modules/ppq/dto/ppq-post.dto.ts
@@ -1,16 +1,16 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { Type } from 'class-transformer';
 import {
   IsBoolean,
-  IsDate,
   IsEnum,
   IsNotEmpty,
   IsOptional,
   IsString,
+  Validate,
 } from '@nestjs/class-validator';
 import { GovMinistriesEnum } from '../../../common/enums/gov-ministries.enum';
 import { PiaTypesEnum } from '../../../common/enums/pia-types.enum';
 import { DelegatedReviewTypesEnum } from '../../../common/enums/delegated-review-types.enum';
+import { DateStringValidator } from 'src/common/validators/date-string.validator';
 
 export class PpqPostDTO {
   @IsString()
@@ -54,11 +54,15 @@ export class PpqPostDTO {
   })
   delegatedReviewType: DelegatedReviewTypesEnum;
 
-  @IsDate()
+  @IsString()
   @IsOptional()
-  @Type(() => Date)
-  @ApiProperty({ type: Date, required: false })
-  proposedStartDate?: Date;
+  @Validate(DateStringValidator)
+  @ApiProperty({
+    type: String,
+    required: false,
+    example: '2022/06/20',
+  })
+  proposedStartDate?: string;
 
   @IsBoolean()
   @IsOptional()

--- a/src/backend/src/modules/ppq/entities/ppq.entity.ts
+++ b/src/backend/src/modules/ppq/entities/ppq.entity.ts
@@ -37,10 +37,10 @@ export class PpqEntity extends BaseEntity {
 
   @Column({
     name: 'proposed_start_date',
-    type: 'timestamptz',
+    type: 'character varying',
     nullable: true,
   })
-  proposedStartDate: Date;
+  proposedStartDate: string;
 
   @Column({
     name: 'has_sensitive_personal_information',

--- a/src/backend/src/modules/ppq/ppq.service.ts
+++ b/src/backend/src/modules/ppq/ppq.service.ts
@@ -66,9 +66,7 @@ export class PpqService {
         ministry: ministry || '',
         piaType: piaType || '',
         delegatedReviewType: delegatedReviewType,
-        proposedStartDate: ppqForm.proposedStartDate
-          ? shortDate(ppqForm.proposedStartDate)
-          : '',
+        proposedStartDate: ppqForm.proposedStartDate || '',
         description: ppqForm.description
           ? marked.parse(ppqForm.description)
           : '',

--- a/src/backend/test/unit/common/validators/date-string.validator.spec.ts
+++ b/src/backend/test/unit/common/validators/date-string.validator.spec.ts
@@ -1,0 +1,43 @@
+import { DateStringValidator } from 'src/common/validators/date-string.validator';
+
+/**
+ * @Description
+ * This file tests the contents of common/validators/data-string.validator.ts
+ */
+describe('DateStringValidator', () => {
+  /**
+   * @method validate
+   *
+   * @input -  Date string
+   * @output - boolean
+   *
+   * @description
+   * This test suite validates if the provided date string matches the YYYY/MM/DD format
+   */
+  describe('`validate` method', () => {
+    it('succeeds when expected input is provided', () => {
+      const validator = new DateStringValidator();
+
+      expect(validator.validate('2022/12/21')).toBe(true); // correct date
+      expect(validator.validate('2020/01/01')).toBe(true); // correct date
+      expect(validator.validate('2020/02/29')).toBe(true); // leap year
+      expect(validator.validate('2021/02/29')).toBe(false); // not a leap year
+      expect(validator.validate('1900/02/29')).toBe(false); // not a leap year
+      expect(validator.validate('1970/01/32')).toBe(false); // invalid date
+      expect(validator.validate('1970/01/00')).toBe(false); // invalid date
+      expect(validator.validate('1970/10/1')).toBe(false); // not a two digit date
+      expect(validator.validate('1970/13/01')).toBe(false); // invalid month
+      expect(validator.validate('2018/14/29')).toBe(false); // invalid month
+      expect(validator.validate('2018/00/29')).toBe(false); // invalid month
+      expect(validator.validate('2018/4/29')).toBe(false); // not a two digit month
+      expect(validator.validate('0999/14/29')).toBe(false); // invalid year
+      expect(validator.validate('3001/14/29')).toBe(false); // invalid year
+      expect(validator.validate('12/14/29')).toBe(false); // neither valid nor a four digit valid year
+      expect(validator.validate('3ccc/1a/2b')).toBe(false); // invalid characters
+      expect(validator.validate('1234567890')).toBe(false); // invalid format
+      expect(validator.validate('cccc/aa/bb')).toBe(false); // invalid characters
+      expect(validator.validate(null)).toBe(false); // null check
+      expect(validator.validate('')).toBe(false); // empty check
+    });
+  });
+});

--- a/src/frontend/src/pages/PPQFormPage/PPQFormPage.tsx
+++ b/src/frontend/src/pages/PPQFormPage/PPQFormPage.tsx
@@ -23,6 +23,7 @@ import Alert from '../../components/common/Alert';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { PiaTypesEnum } from '../../types/enums/pia-types.enum';
 import { DelegatedReviewTypesEnum } from '../../types/enums/delegated-review-types.enum';
+import { dateToString } from '../../utils/date';
 
 const PPQFormPage = () => {
   const navigate = useNavigate();
@@ -37,7 +38,7 @@ const PPQFormPage = () => {
     DelegatedReviewTypesEnum | string | null
   >();
   const [containsStartDate, setContainsStartDate] = useState('Yes');
-  const [startDate, setStartDate] = useState(null);
+  const [startDate, setStartDate] = useState<Date | null>(null);
   const [description, setDescription] = useState('');
   const [checkedPIItems, setCheckedPIItems] = useState({
     hasSensitivePersonalInformation: false,
@@ -94,7 +95,10 @@ const PPQFormPage = () => {
       title: title,
       ministry: ministry,
       description: description,
-      proposedStartDate: startDate,
+      proposedStartDate:
+        startDate && containsStartDate === 'Yes'
+          ? dateToString(startDate)
+          : null,
       piaType: piaType,
       delegatedReviewType: delegatedReviewType,
       ...checkedPIItems,
@@ -292,7 +296,7 @@ const PPQFormPage = () => {
                     </label>
                     <CustomInputDate
                       key="startDate"
-                      placeholderText={'yyyy-mm-dd'}
+                      placeholderText={'yyyy/mm/dd'}
                       dateFormat="yyyy/MM/dd"
                       selected={startDate === null ? null : startDate}
                       onChange={(date: any) => setStartDate(date)}

--- a/src/frontend/src/types/interfaces/ppq-form.interface.ts
+++ b/src/frontend/src/types/interfaces/ppq-form.interface.ts
@@ -17,6 +17,6 @@ export interface IPPQForm {
   hasBcServicesCardOnboarding?: boolean;
   hasAiOrMl?: boolean;
   hasPartnershipNonMinistry?: boolean;
-  proposedStartDate?: Date | null;
+  proposedStartDate?: string | null;
   description?: string;
 }


### PR DESCRIPTION
# Description

Currently, we are storing our PPQ with proposed start date as Timestamp in the database. This is problematic. Changing it to store date only in YYYY/MM/DD format.

[*This PR updates existing data via migration; May require local API container to be restarted.*]

This PR includes the following proposed change(s):

- Updated `proposedStartDate` in PPQ to date string [YYYY/MM/DD]
- Migration to convert existing timestamp to dateString
- Custom Validator with relevant Test cases
- Corresponding Frontend changes to send date string instead of timestamp

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

## How Has This Been Tested?

Tested by creating PPQs with and without proposedStartDate. Also tested via Swagger and the test cases written in the code.

## Development Dependency Working Agreement
- [x] My code DOES NOT include the importing of new dependencies into the DPIA ecosystem
- [ ] My code DOES include the importing of new dependencies into the DPIA ecosystem
**If new dependencies are being introduced to the DPIA ecosystem:**
- [ ] The functionality of the dependency drastically reduces code complexity and makes my changes more easily maintainable and readible 
- [ ] The dependency being introduced does not contain multiple layers of nested dependencies introducing maintainability complexity to the DPIA ecosystem

## Frontend Development Changes
- [ ] N/A
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to project documentation or diagrams that reflect my changes
- [ ] New and existing unit tests pass locally with my changes
- [x] My code follows Airbnb React Style Guidelines

## API Development Changes
- [ ] N/A
- [x] I have performed a self-review of my own code
- [x] My code follows standards and practices outlined in the BC Government API Development Guidelines
- [x] New and existing unit tests pass locally with my changes
- [x] My changes includes Swagger documentation updates that reflect the changes I am introducing

## Definition of Done

![Definition of Done](https://raw.githubusercontent.com/bcgov/cirmo-dpia/main/.github/assets/DoD.jpg)
