### PR TITLE
[UTOPIA-777] update submittedat in frontend end

### DIFF
--- a/src/backend/src/modules/pia-intake/pia-intake.service.ts
+++ b/src/backend/src/modules/pia-intake/pia-intake.service.ts
@@ -40,10 +40,8 @@ export class PiaIntakeService {
     user: KeycloakUser,
   ): Promise<GetPiaIntakeRO> {
     // update submittedAt column if it is first time submit
-    createPiaIntakeDto.submittedAt = this.updatedSubmittedAt(
-      createPiaIntakeDto.submittedAt,
-      createPiaIntakeDto.status,
-    );
+    this.updateSubmittedAt(createPiaIntakeDto);
+
     const piaInfoForm: PiaIntakeEntity = await this.piaIntakeRepository.save({
       ...createPiaIntakeDto,
       createdByGuid: user.idir_user_guid,
@@ -88,10 +86,8 @@ export class PiaIntakeService {
     delete updatePiaIntakeDto.saveId;
 
     // update submittedAt column if it is first time submit
-    updatePiaIntakeDto.submittedAt = this.updatedSubmittedAt(
-      updatePiaIntakeDto.submittedAt,
-      updatePiaIntakeDto.status,
-    );
+    this.updateSubmittedAt(updatePiaIntakeDto);
+
     // update the record with the provided keys [using save instead of update updates the @UpdateDateColumn]
     await this.piaIntakeRepository.save({
       id,
@@ -412,13 +408,13 @@ export class PiaIntakeService {
   }
 
   /**
-   * @method updatedSubmittedAt
+   * @method updateSubmittedAt
    *
    * @description
    * This method will update submittedAt column in pia-intake table for the first time the drafter submit their pia
    */
-  updatedSubmittedAt = (submittedAt: Date, status: PiaIntakeStatusEnum) => {
-    if (!submittedAt && status === PiaIntakeStatusEnum.MPO_REVIEW)
-      return (submittedAt = new Date());
+  updateSubmittedAt = (dto: CreatePiaIntakeDto | UpdatePiaIntakeDto) => {
+    if (!dto.submittedAt && dto.status === PiaIntakeStatusEnum.MPO_REVIEW)
+      dto.submittedAt = new Date();
   };
 }

--- a/src/backend/src/modules/pia-intake/pia-intake.service.ts
+++ b/src/backend/src/modules/pia-intake/pia-intake.service.ts
@@ -39,6 +39,11 @@ export class PiaIntakeService {
     createPiaIntakeDto: CreatePiaIntakeDto,
     user: KeycloakUser,
   ): Promise<GetPiaIntakeRO> {
+    // update submittedAt column if it is first time submit
+    createPiaIntakeDto.submittedAt = this.updatedSubmittedAt(
+      createPiaIntakeDto.submittedAt,
+      createPiaIntakeDto.status,
+    );
     const piaInfoForm: PiaIntakeEntity = await this.piaIntakeRepository.save({
       ...createPiaIntakeDto,
       createdByGuid: user.idir_user_guid,
@@ -82,6 +87,11 @@ export class PiaIntakeService {
     // remove the provided saveId
     delete updatePiaIntakeDto.saveId;
 
+    // update submittedAt column if it is first time submit
+    updatePiaIntakeDto.submittedAt = this.updatedSubmittedAt(
+      updatePiaIntakeDto.submittedAt,
+      updatePiaIntakeDto.status,
+    );
     // update the record with the provided keys [using save instead of update updates the @UpdateDateColumn]
     await this.piaIntakeRepository.save({
       id,
@@ -400,4 +410,15 @@ export class PiaIntakeService {
     // Throw Forbidden user access if none of the above scenarios are met
     throw new ForbiddenException();
   }
+
+  /**
+   * @method updatedSubmittedAt
+   *
+   * @description
+   * This method will update submittedAt column in pia-intake table for the first time the drafter submit their pia
+   */
+  updatedSubmittedAt = (submittedAt: Date, status: PiaIntakeStatusEnum) => {
+    if (!submittedAt && status === PiaIntakeStatusEnum.MPO_REVIEW)
+      return (submittedAt = new Date());
+  };
 }

--- a/src/backend/test/unit/pia-intake/pia-intake.service.spec.ts
+++ b/src/backend/test/unit/pia-intake/pia-intake.service.spec.ts
@@ -1335,131 +1335,7 @@ describe('PiaIntakeService', () => {
       expect(result).toBe(piaIntakeROMock);
     });
 
-    // Scenario 3: Test succeeds,  user submitted their pia in first time will update submittedAt column
-    it('succeeds call repository.update to update submittedAt column when the drafter first submit pia', async () => {
-      const piaIntakeMock = { ...piaIntakeEntityMock };
-      const piaIntakeROMock = { ...getPiaIntakeROMock };
-
-      const updatePiaIntakeDto = {
-        status: PiaIntakeStatusEnum.MPO_REVIEW,
-        saveId: 1,
-        submittedAt: null,
-      };
-      const user: KeycloakUser = { ...keycloakUserMock };
-      const userRoles = [RolesEnum.MPO_CITZ];
-      const id = 1;
-
-      service.findOneBy = jest.fn(async () => {
-        delay(10);
-        return piaIntakeMock;
-      });
-
-      service.findOneById = jest.fn(async () => {
-        delay(10);
-        return piaIntakeROMock;
-      });
-
-      service.validateUserAccess = jest.fn(() => true);
-      service.updateSubmittedAt = jest.fn(() => {
-        return { ...updatePiaIntakeDto, submittedAt: new Date() };
-      });
-      piaIntakeRepository.save = jest.fn(async () => {
-        delay(10);
-        return { ...piaIntakeMock, ...updatePiaIntakeDto };
-      });
-
-      const result = await service.update(
-        id,
-        updatePiaIntakeDto,
-        user,
-        userRoles,
-      );
-
-      expect(service.findOneBy).toHaveBeenCalledWith({ id });
-      expect(service.validateUserAccess).toHaveBeenCalledWith(
-        user,
-        userRoles,
-        piaIntakeEntityMock,
-      );
-      expect(service.updateSubmittedAt).toHaveBeenCalledWith(
-        updatePiaIntakeDto,
-      );
-      expect(piaIntakeRepository.save).toHaveBeenCalledWith({
-        id,
-        ...updatePiaIntakeDto,
-        saveId: 2,
-        updatedByGuid: user.idir_user_guid,
-        updatedByUsername: user.idir_username,
-        updatedByDisplayName: user.display_name,
-      });
-      expect(service.findOneById).toHaveBeenCalledWith(id, user, userRoles);
-
-      expect(result).toBe(piaIntakeROMock);
-    });
-
-    // Scenario 4: Test succeeds,  if the submittedAt column already set, no update in future submit action
-    it('succeeds call repository.update but not update submittedAt column when the column not null', async () => {
-      const piaIntakeMock = { ...piaIntakeEntityMock };
-      const piaIntakeROMock = { ...getPiaIntakeROMock };
-
-      const updatePiaIntakeDto = {
-        status: PiaIntakeStatusEnum.MPO_REVIEW,
-        saveId: 1,
-        submittedAt: new Date('2022-12-17T03:24:00'),
-      };
-      const user: KeycloakUser = { ...keycloakUserMock };
-      const userRoles = [RolesEnum.MPO_CITZ];
-      const id = 1;
-
-      service.findOneBy = jest.fn(async () => {
-        delay(10);
-        return piaIntakeMock;
-      });
-
-      service.findOneById = jest.fn(async () => {
-        delay(10);
-        return piaIntakeROMock;
-      });
-
-      service.validateUserAccess = jest.fn(() => true);
-      service.updateSubmittedAt = jest.fn(() => {
-        return { ...updatePiaIntakeDto };
-      });
-      piaIntakeRepository.save = jest.fn(async () => {
-        delay(10);
-        return { ...piaIntakeMock, ...updatePiaIntakeDto };
-      });
-
-      const result = await service.update(
-        id,
-        updatePiaIntakeDto,
-        user,
-        userRoles,
-      );
-
-      expect(service.findOneBy).toHaveBeenCalledWith({ id });
-      expect(service.validateUserAccess).toHaveBeenCalledWith(
-        user,
-        userRoles,
-        piaIntakeEntityMock,
-      );
-      expect(service.updateSubmittedAt).toHaveBeenCalledWith(
-        updatePiaIntakeDto,
-      );
-      expect(piaIntakeRepository.save).toHaveBeenCalledWith({
-        id,
-        ...updatePiaIntakeDto,
-        saveId: 2,
-        updatedByGuid: user.idir_user_guid,
-        updatedByUsername: user.idir_username,
-        updatedByDisplayName: user.display_name,
-      });
-      expect(service.findOneById).toHaveBeenCalledWith(id, user, userRoles);
-
-      expect(result).toBe(piaIntakeROMock);
-    });
-
-    // Scenario 5: Conflict exception: Fails if the user tries to update a stale version
+    // Scenario 3: Conflict exception: Fails if the user tries to update a stale version
     it('Fails if the user tries to update a stale version', async () => {
       const piaIntakeMock = { ...piaIntakeEntityMock, saveId: 10 };
 
@@ -1496,7 +1372,7 @@ describe('PiaIntakeService', () => {
       );
     });
 
-    // Scenario 6: succeeds and update submittedAt with current value if status is changed to MPO_REVIEW
+    // Scenario 4: succeeds and update submittedAt with current value if status is changed to MPO_REVIEW
     it('succeeds and update submittedAt with current value if status is changed to MPO_REVIEW', async () => {
       const piaIntakeMock = { ...piaIntakeEntityMock };
       const piaIntakeROMock = { ...getPiaIntakeROMock };

--- a/src/frontend/src/pages/PIADetailPage/index.tsx
+++ b/src/frontend/src/pages/PIADetailPage/index.tsx
@@ -177,6 +177,7 @@ const PIADetailPage = () => {
     const requestBody: Partial<IPIAIntake> = {
       status: statusLocal,
       saveId: pia?.saveId,
+      submittedAt: pia?.submittedAt,
     };
     try {
       const res = await updatePiaHttpRequest(
@@ -211,6 +212,7 @@ const PIADetailPage = () => {
         ? {
             status: PiaStatuses.MPO_REVIEW,
             saveId: pia?.saveId,
+            submittedAt: pia?.submittedAt,
           }
         : {
             status: PiaStatuses.EDIT_IN_PROGRESS,
@@ -223,9 +225,6 @@ const PIADetailPage = () => {
       }
 
       if (buttonValue === 'submit') {
-        // here will check if this is the first submit, if so will add submittedAt property
-        // otherwise no action needed
-        if (!pia?.submittedAt) requestBody.submittedAt = new Date();
         const updatedPia = await updatePiaHttpRequest(pia.id, requestBody);
         setPia(updatedPia);
         navigate(routes.PIA_INTAKE_RESULT, {
@@ -436,7 +435,7 @@ const PIADetailPage = () => {
                 </div>
               </div>
               <div className="col col-md-4">
-                {pia.submittedAt ? dateToString(pia.submittedAt) : 'N/A'}
+                {pia.submittedAt ? dateToString(pia.submittedAt) : ''}
               </div>
               <div className="col col-md-4">{dateToString(pia.updatedAt)}</div>
             </div>

--- a/src/frontend/src/pages/PIADetailPage/index.tsx
+++ b/src/frontend/src/pages/PIADetailPage/index.tsx
@@ -5,9 +5,9 @@ import {
 import {
   faFileArrowDown,
   faPenToSquare,
+  faChevronDown,
 } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faChevronDown } from '@fortawesome/free-solid-svg-icons';
 import { dateToString } from '../../utils/date';
 import { statusList } from '../../utils/status';
 import messages from './messages';
@@ -223,6 +223,9 @@ const PIADetailPage = () => {
       }
 
       if (buttonValue === 'submit') {
+        // here will check if this is the first submit, if so will add submittedAt property
+        // otherwise no action needed
+        if (!pia?.submittedAt) requestBody.submittedAt = new Date();
         const updatedPia = await updatePiaHttpRequest(pia.id, requestBody);
         setPia(updatedPia);
         navigate(routes.PIA_INTAKE_RESULT, {
@@ -432,7 +435,9 @@ const PIADetailPage = () => {
                   )}
                 </div>
               </div>
-              <div className="col col-md-4">{dateToString(pia.createdAt)}</div>
+              <div className="col col-md-4">
+                {pia.submittedAt ? dateToString(pia.submittedAt) : 'N/A'}
+              </div>
               <div className="col col-md-4">{dateToString(pia.updatedAt)}</div>
             </div>
           </div>

--- a/src/frontend/src/pages/PIAIntakeForm/index.tsx
+++ b/src/frontend/src/pages/PIAIntakeForm/index.tsx
@@ -203,13 +203,9 @@ const PIAIntakeFormPage = () => {
     const buttonValue = event.target.value;
     try {
       if (buttonValue === 'submit') {
-        const reqBody: Partial<IPIAIntake> = {
+        const updatedPia = await upsertAndUpdatePia({
           status: PiaStatuses.MPO_REVIEW,
-        };
-        // here will check if this is the first submit, if so will add submittedAt property
-        // otherwise no action needed
-        if (!pia?.submittedAt) reqBody.submittedAt = new Date();
-        const updatedPia = await upsertAndUpdatePia(reqBody);
+        });
         navigate(routes.PIA_INTAKE_RESULT, {
           state: { result: updatedPia },
         });

--- a/src/frontend/src/pages/PIAIntakeForm/index.tsx
+++ b/src/frontend/src/pages/PIAIntakeForm/index.tsx
@@ -203,9 +203,13 @@ const PIAIntakeFormPage = () => {
     const buttonValue = event.target.value;
     try {
       if (buttonValue === 'submit') {
-        const updatedPia = await upsertAndUpdatePia({
+        const reqBody: Partial<IPIAIntake> = {
           status: PiaStatuses.MPO_REVIEW,
-        });
+        };
+        // here will check if this is the first submit, if so will add submittedAt property
+        // otherwise no action needed
+        if (!pia?.submittedAt) reqBody.submittedAt = new Date();
+        const updatedPia = await upsertAndUpdatePia(reqBody);
         navigate(routes.PIA_INTAKE_RESULT, {
           state: { result: updatedPia },
         });

--- a/src/frontend/src/types/interfaces/pia-intake.interface.ts
+++ b/src/frontend/src/types/interfaces/pia-intake.interface.ts
@@ -23,6 +23,7 @@ export interface IPIAIntake {
   updatedAt?: Date;
   status?: string;
   saveId?: number;
+  submittedAt?: Date | null;
 }
 
 export interface IPIAIntakeResponse {


### PR DESCRIPTION


# Description

This PR includes the following proposed change(s):

- Display the submitteAt in pia intake detail page with the correct value, previous we use createdAt, now will use the new submittedAt column to show the correct date

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Development Dependency Working Agreement
- [x] My code DOES NOT include the importing of new dependencies into the DPIA ecosystem
- [ ] My code DOES include the importing of new dependencies into the DPIA ecosystem
**If new dependencies are being introduced to the DPIA ecosystem:**
- [ ] The functionality of the dependency drastically reduces code complexity and makes my changes more easily maintainable and readible 
- [ ] The dependency being introduced does not contain multiple layers of nested dependencies introducing maintainability complexity to the DPIA ecosystem

## Frontend Development Changes
- [ ] N/A
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to project documentation or diagrams that reflect my changes
- [ ] New and existing unit tests pass locally with my changes
- [ ] My code follows Airbnb React Style Guidelines

## API Development Changes
- [x] N/A
- [ ] I have performed a self-review of my own code
- [ ] My code follows standards and practices outlined in the BC Government API Development Guidelines
- [ ] New and existing unit tests pass locally with my changes
- [ ] My changes includes Swagger documentation updates that reflect the changes I am introducing

## Definition of Done

![Definition of Done](https://raw.githubusercontent.com/bcgov/cirmo-dpia/main/.github/assets/DoD.jpg)
