### PR TITLE
[UTOPIA-848] Add new nextSteps flags to pia-intake

### DIFF
--- a/src/backend/src/migrations/1678142798474-piaIntakeAddColumnsNextStepFlags.ts
+++ b/src/backend/src/migrations/1678142798474-piaIntakeAddColumnsNextStepFlags.ts
@@ -1,0 +1,27 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class PiaIntakeAddColumnsNextStepFlags1678142798474
+  implements MigrationInterface
+{
+  name = 'piaIntakeAddColumnsNextStepFlags1678142798474';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "pia-intake" DROP COLUMN "test"`);
+    await queryRunner.query(
+      `ALTER TABLE "pia-intake" ADD "is_next_steps_seen_for_delegated_flow" boolean NOT NULL DEFAULT false`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "pia-intake" ADD "is_next_steps_seen_for_non_delegated_flow" boolean NOT NULL DEFAULT false`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "pia-intake" DROP COLUMN "is_next_steps_seen_for_non_delegated_flow"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "pia-intake" DROP COLUMN "is_next_steps_seen_for_delegated_flow"`,
+    );
+    await queryRunner.query(`ALTER TABLE "pia-intake" ADD "test" jsonb`);
+  }
+}

--- a/src/backend/src/modules/pia-intake/dto/create-pia-intake.dto.ts
+++ b/src/backend/src/modules/pia-intake/dto/create-pia-intake.dto.ts
@@ -187,6 +187,24 @@ export class CreatePiaIntakeDto {
   })
   submittedAt: Date;
 
+  @IsBoolean()
+  @IsOptional()
+  @ApiProperty({
+    type: Boolean,
+    required: false,
+    example: piaIntakeEntityMock.isNextStepsSeenForDelegatedFlow,
+  })
+  isNextStepsSeenForDelegatedFlow: boolean;
+
+  @IsBoolean()
+  @IsOptional()
+  @ApiProperty({
+    type: Boolean,
+    required: false,
+    example: piaIntakeEntityMock.isNextStepsSeenForNonDelegatedFlow,
+  })
+  isNextStepsSeenForNonDelegatedFlow: boolean;
+
   @IsObject()
   @IsOptional()
   @IsNotEmptyObject()

--- a/src/backend/src/modules/pia-intake/entities/pia-intake.entity.ts
+++ b/src/backend/src/modules/pia-intake/entities/pia-intake.entity.ts
@@ -137,6 +137,20 @@ export class PiaIntakeEntity extends BaseEntity {
   submittedAt: Date;
 
   @Column({
+    name: 'is_next_steps_seen_for_delegated_flow',
+    nullable: false,
+    default: false,
+  })
+  isNextStepsSeenForDelegatedFlow: boolean;
+
+  @Column({
+    name: 'is_next_steps_seen_for_non_delegated_flow',
+    nullable: false,
+    default: false,
+  })
+  isNextStepsSeenForNonDelegatedFlow: boolean;
+
+  @Column({
     name: 'collection_use_and_disclosure',
     type: 'jsonb',
     nullable: true,

--- a/src/backend/src/modules/pia-intake/mocks/create-pia-intake.mock.ts
+++ b/src/backend/src/modules/pia-intake/mocks/create-pia-intake.mock.ts
@@ -30,6 +30,8 @@ export const piaIntakeEntityMock: CreatePiaIntakeDto = {
     `,
   hasAddedPiToDataElements: false,
   submittedAt: new Date(),
+  isNextStepsSeenForDelegatedFlow: false,
+  isNextStepsSeenForNonDelegatedFlow: false,
   riskMitigation: `The film was released on [Blu-ray](https://en.wikipedia.org/wiki/Blu-ray) and [DVD](https://en.wikipedia.org/wiki/DVD) February 8, 2022 by [Warner Bros. Home Entertainment](https://en.wikipedia.org/wiki/Warner_Bros._Home_Entertainment), with the 4K Ultra HD release through [Warner Archive Collection](https://en.wikipedia.org/wiki/Warner_Archive_Collection) on the same date.`,
   collectionUseAndDisclosure: {
     steps: [

--- a/src/backend/test/util/mocks/data/pia-intake.mock.ts
+++ b/src/backend/test/util/mocks/data/pia-intake.mock.ts
@@ -35,6 +35,8 @@ const piaIntakeDataMock = {
   status: PiaIntakeStatusEnum.MPO_REVIEW,
   saveId: 1,
   submittedAt: new Date(),
+  isNextStepsSeenForDelegatedFlow: false,
+  isNextStepsSeenForNonDelegatedFlow: false,
   collectionUseAndDisclosure: {
     steps: [
       {


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- [PIA Intake table] New column added - is_next_steps_seen_for_delegated_flow
- [PIA Intake table] New column added - is_next_steps_seen_for_non_delegated_flow
- Migration added
- DTO updated
- Tests updated

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

## How Has This Been Tested?

via Swagger

## Development Dependency Working Agreement
- [ ] My code DOES NOT include the importing of new dependencies into the DPIA ecosystem
- [ ] My code DOES include the importing of new dependencies into the DPIA ecosystem
**If new dependencies are being introduced to the DPIA ecosystem:**
- [ ] The functionality of the dependency drastically reduces code complexity and makes my changes more easily maintainable and readible 
- [ ] The dependency being introduced does not contain multiple layers of nested dependencies introducing maintainability complexity to the DPIA ecosystem

## Frontend Development Changes
- [x] N/A
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to project documentation or diagrams that reflect my changes
- [ ] New and existing unit tests pass locally with my changes
- [ ] My code follows Airbnb React Style Guidelines

## API Development Changes
- [ ] N/A
- [x] I have performed a self-review of my own code
- [x] My code follows standards and practices outlined in the BC Government API Development Guidelines
- [x] New and existing unit tests pass locally with my changes
- [x] My changes includes Swagger documentation updates that reflect the changes I am introducing

## Definition of Done

![Definition of Done](https://raw.githubusercontent.com/bcgov/cirmo-dpia/main/.github/assets/DoD.jpg)
