### PR TITLE
UTOPIA-886: Add External link behaviour to all “more info” links on Storing PI tab

### DIFF
--- a/src/frontend/src/components/public/PIAFormTabs/storingPersonalInformation/index.tsx
+++ b/src/frontend/src/components/public/PIAFormTabs/storingPersonalInformation/index.tsx
@@ -14,6 +14,8 @@ import {
   ServiceProviderDetails,
 } from './interfaces';
 import Messages from './messages';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faUpRightFromSquare } from '@fortawesome/free-solid-svg-icons';
 
 const StoringPersonalInformation = () => {
   const [pia, piaStateChangeHandler] =
@@ -651,12 +653,31 @@ const StoringPersonalInformation = () => {
             {storingPersonalInformationForm.sensitivePersonalInformation
               .doesInvolve === YesNoInput.YES && (
               <div className="pt-5 form__md-question">
-                <MDEditor.Markdown
-                  source={
+                <p>
+                  {
                     Messages.SensitivePersonalInformation
                       .SensitivePersonalInformationDislosedUnderFOIPPA.en
                   }
-                />
+                  <a
+                    href={
+                      Messages.SensitivePersonalInformation
+                        .SensitivePersonalInformationDislosedUnderFOIPPA.Link
+                    }
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    {
+                      Messages.SensitivePersonalInformation
+                        .SensitivePersonalInformationDislosedUnderFOIPPA
+                        .LinkText.en
+                    }
+                    <FontAwesomeIcon
+                      icon={faUpRightFromSquare}
+                      className="helper-text__link-icon"
+                    />
+                  </a>
+                  ?
+                </p>
                 {sensitivePiDisclosedOutsideCanada.map((radio, index) => (
                   <Radio key={index} {...radio} />
                 ))}
@@ -673,9 +694,19 @@ const StoringPersonalInformation = () => {
             <section className="form__section">
               <div className="py-3 form__section-header">
                 <h3>{Messages.AssessmentOfDisclosures.H3Text.en}</h3>
-                <MDEditor.Markdown
-                  source={Messages.AssessmentOfDisclosures.PText.en}
-                />
+                {Messages.AssessmentOfDisclosures.HelperText.en}
+                <a
+                  href={Messages.AssessmentOfDisclosures.HelperText.Link}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  {Messages.AssessmentOfDisclosures.HelperText.LinkText.en}
+                  <FontAwesomeIcon
+                    icon={faUpRightFromSquare}
+                    className="helper-text__link-icon"
+                  />
+                </a>
+                .
               </div>
               <div className="card-wrapper py-5 px-5">
                 <div>
@@ -724,12 +755,65 @@ const StoringPersonalInformation = () => {
                     <p>
                       {Messages.AssessmentOfDisclosures.ContractualTerms.en}
                     </p>
-                    <MDEditor.Markdown
-                      source={
+                    {
+                      Messages.AssessmentOfDisclosures.ContractualTerms
+                        .HelperText.PartOne.en
+                    }
+                    <a
+                      href={
                         Messages.AssessmentOfDisclosures.ContractualTerms
-                          .HelperText.en
+                          .HelperText.PrivacyProtectionLink
                       }
-                    />
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      {
+                        Messages.AssessmentOfDisclosures.ContractualTerms
+                          .HelperText.PrivacyProtectionLinkText.en
+                      }
+                      <FontAwesomeIcon
+                        icon={faUpRightFromSquare}
+                        className="helper-text__link-icon"
+                      />
+                    </a>
+                    {
+                      Messages.AssessmentOfDisclosures.ContractualTerms
+                        .HelperText.PartTwo.en
+                    }
+                    <a
+                      href={
+                        Messages.AssessmentOfDisclosures.ContractualTerms
+                          .HelperText.PrivacyHelplineEmailLink
+                      }
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      {
+                        Messages.AssessmentOfDisclosures.ContractualTerms
+                          .HelperText.PrivacyHelplineEmailLinkText.en
+                      }
+                    </a>
+                    {
+                      Messages.AssessmentOfDisclosures.ContractualTerms
+                        .HelperText.PartThree.en
+                    }
+                    <a
+                      href={
+                        Messages.AssessmentOfDisclosures.ContractualTerms
+                          .HelperText.PrivacyHelplinePhoneLink
+                      }
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      {
+                        Messages.AssessmentOfDisclosures.ContractualTerms
+                          .HelperText.PrivacyHelplinePhoneLinkText.en
+                      }
+                    </a>
+                    {
+                      Messages.AssessmentOfDisclosures.ContractualTerms
+                        .HelperText.PartFour.en
+                    }
                   </div>
                   <MDEditor
                     preview={isMPORole() ? 'edit' : 'preview'}

--- a/src/frontend/src/components/public/PIAFormTabs/storingPersonalInformation/messages.ts
+++ b/src/frontend/src/components/public/PIAFormTabs/storingPersonalInformation/messages.ts
@@ -26,15 +26,23 @@ export default {
       en: `Does your initiative involve sensitive personal information?`,
     },
     SensitivePersonalInformationDislosedUnderFOIPPA: {
-      en: `Is the sensitive personal information being disclosed outside of Canada under [FOIPPA section 33(2)(f)](https://www2.gov.bc.ca/gov/content/governments/services-for-government/policies-procedures/foippa-manual/disclosure-personal-information)?`,
+      en: `Is the sensitive personal information being disclosed outside of Canada under `,
+      LinkText: {
+        en: `FOIPPA section 33(2)(f)`,
+      },
+      Link: `https://www2.gov.bc.ca/gov/content/governments/services-for-government/policies-procedures/foippa-manual/disclosure-personal-information`,
     },
   },
   AssessmentOfDisclosures: {
     H3Text: {
       en: `Assessment of disclosures outside of Canada`,
     },
-    PText: {
-      en: `You will likely need your MPO's help to complete this section. More help is available in the [Guidance on Disclosures Outside of Canada](https://www2.gov.bc.ca/gov/content/governments/services-for-government/information-management-technology/privacy/privacy-impact-assessments/guidance-on-disclosures-outside-of-canada).`,
+    HelperText: {
+      en: `You will likely need your MPO's help to complete this section. More help is available in the `,
+      LinkText: {
+        en: `Guidance on Disclosures Outside of Canada`,
+      },
+      Link: `https://www2.gov.bc.ca/gov/content/governments/services-for-government/information-management-technology/privacy/privacy-impact-assessments/guidance-on-disclosures-outside-of-canada`,
     },
     SensitivePersonalInformationStoredByServiceProvider: {
       en: `Is the sensitive personal information stored by a service provider?`,
@@ -45,7 +53,30 @@ export default {
     ContractualTerms: {
       en: `Describe the contractual terms in place (if applicable).`,
       HelperText: {
-        en: `For example, indicate if you have attached the Privacy Protection Schedule. If you wish to modify the [Privacy Protection Schedule](https://www2.gov.bc.ca/gov/content/governments/services-for-government/information-management-technology/privacy/agreements-contracts/privacy-protection-schedule), email [Privacy.Helpline@gov.bc.ca](mailto:privacy.helpline@gov.bc.ca), or call [250 356-1851](tel:+12503561851) for approval.`,
+        PartOne: {
+          en: `For example, indicate if you have attached the Privacy Protection Schedule. If you wish to modify the `,
+        },
+        PrivacyProtectionLinkText: {
+          en: `Privacy Protection Schedule`,
+        },
+        PrivacyProtectionLink: `https://www2.gov.bc.ca/gov/content/governments/services-for-government/information-management-technology/privacy/agreements-contracts/privacy-protection-schedule`,
+        PartTwo: {
+          en: `, email `,
+        },
+        PrivacyHelplineEmailLinkText: {
+          en: `Privacy.Helpline@gov.bc.ca`,
+        },
+        PrivacyHelplineEmailLink: `mailto:privacy.helpline@gov.bc.ca`,
+        PartThree: {
+          en: `, or call `,
+        },
+        PrivacyHelplinePhoneLinkText: {
+          en: `250 356-1851`,
+        },
+        PrivacyHelplinePhoneLink: `tel:+12503561851`,
+        PartFour: {
+          en: ` for approval.`,
+        },
       },
     },
     ServiceProviderTableColumnHeaders: {


### PR DESCRIPTION

# Description

This PR includes the following proposed change(s):

- External links now include an icon
- External links now open in a new tab

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

## How Has This Been Tested?

- Visual assessment of style changes
- Clicked links to assert that behaviour was as expected

## Development Dependency Working Agreement
- [x] My code DOES NOT include the importing of new dependencies into the DPIA ecosystem
- [ ] My code DOES include the importing of new dependencies into the DPIA ecosystem
**If new dependencies are being introduced to the DPIA ecosystem:**
- [ ] The functionality of the dependency drastically reduces code complexity and makes my changes more easily maintainable and readible 
- [ ] The dependency being introduced does not contain multiple layers of nested dependencies introducing maintainability complexity to the DPIA ecosystem

## Frontend Development Changes
- [ ] N/A
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to project documentation or diagrams that reflect my changes
- [x] New and existing unit tests pass locally with my changes
- [x] My code follows Airbnb React Style Guidelines

## API Development Changes
- [x] N/A
- [ ] I have performed a self-review of my own code
- [ ] My code follows standards and practices outlined in the BC Government API Development Guidelines
- [ ] New and existing unit tests pass locally with my changes
- [ ] My changes includes Swagger documentation updates that reflect the changes I am introducing

## Definition of Done

![Definition of Done](https://raw.githubusercontent.com/bcgov/cirmo-dpia/main/.github/assets/DoD.jpg)
