### PR TITLE
[UTOPIA-961] Spacing between Sidenav and main container + Border bottom drafter fix

### DIFF
--- a/src/frontend/src/components/common/Navbar/_navbar.scss
+++ b/src/frontend/src/components/common/Navbar/_navbar.scss
@@ -15,7 +15,6 @@
   display: flex;
   gap: 1em;
   align-items: center;
-  max-width: 80%;
   list-style: none;
   margin-bottom: 0;
   & :first-child {

--- a/src/frontend/src/components/public/PIAListTable/index.tsx
+++ b/src/frontend/src/components/public/PIAListTable/index.tsx
@@ -30,7 +30,9 @@ const PIAListTable = ({ headings, pias, sorting }: IDataTable) => {
                 className={` ${
                   headings[heading].sorting ? ' enableSorting' : ''
                 } ${
-                  headings[heading].hideOnSmView ? ' d-none d-md-block' : ''
+                  headings[heading].hideOnSmView
+                    ? ' d-none d-md-table-cell'
+                    : ''
                 }`}
                 onClick={() => sorting(heading)}
               >

--- a/src/frontend/src/pages/PIAForm/index.tsx
+++ b/src/frontend/src/pages/PIAForm/index.tsx
@@ -645,7 +645,7 @@ const PIAFormPage = () => {
               isReadOnly={formReadOnly}
             ></PIASideNav>
           </section>
-          <section className="form__container ms-md-auto content__container">
+          <section className="ms-md-3 ms-lg-4 ms-xl-5 content__container">
             {/* Only show the nested routes if it is a NEW Form (no ID) OR if existing form with PIA data is fetched */}
             {!id || initialPiaStateFetched ? (
               <Outlet

--- a/src/frontend/src/sass/_default.scss
+++ b/src/frontend/src/sass/_default.scss
@@ -169,7 +169,6 @@ p {
 
 .content__container {
   flex: 3;
-  margin-left: 3rem;
 }
 
 .component__row--create-new-form {

--- a/src/frontend/src/sass/_sideNav.scss
+++ b/src/frontend/src/sass/_sideNav.scss
@@ -49,6 +49,10 @@
 
     .navbar {
         display: block;
+
+        hr {
+            width: 80%;
+        }
     }
 
     a {


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- [UTOPIA-892] BugFix: Border under Drafter name in smaller screens
- [UTOPIA-961] Spacing between sidebar and main container

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring / Documentation
- [ ] Version change

## How Has This Been Tested?

From 400px to 3000px - all works!

## Development Dependency Working Agreement
- [x] My code DOES NOT include the importing of new dependencies into the DPIA ecosystem
- [ ] My code DOES include the importing of new dependencies into the DPIA ecosystem
**If new dependencies are being introduced to the DPIA ecosystem:**
- [ ] The functionality of the dependency drastically reduces code complexity and makes my changes more easily maintainable and readible 
- [ ] The dependency being introduced does not contain multiple layers of nested dependencies introducing maintainability complexity to the DPIA ecosystem

## Frontend Development Changes
- [ ] N/A
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to project documentation or diagrams that reflect my changes
- [ ] New and existing unit tests pass locally with my changes
- [x] My code follows Airbnb React Style Guidelines

## API Development Changes
- [x] N/A
- [ ] I have performed a self-review of my own code
- [ ] My code follows standards and practices outlined in the BC Government API Development Guidelines
- [ ] New and existing unit tests pass locally with my changes
- [ ] My changes includes Swagger documentation updates that reflect the changes I am introducing

## Definition of Done

![Definition of Done](https://raw.githubusercontent.com/bcgov/cirmo-dpia/main/.github/assets/DoD.jpg)
