### PR TITLE
[UTOPIA-996] fix: user submits intake before autosave

### DIFF
--- a/src/frontend/src/components/public/PIAFormTabs/Next_Steps/index.tsx
+++ b/src/frontend/src/components/public/PIAFormTabs/Next_Steps/index.tsx
@@ -24,27 +24,24 @@ export const PIANextSteps = () => {
   };
 
   useEffect(() => {
-    // Countering UseEffect calling twice issue. Adding timeout for 1 second for second GET call is completed
-    setTimeout(() => {
-      if (pia.hasAddedPiToDataElements === false) {
-        if (pia.isNextStepsSeenForDelegatedFlow) {
-          // redirect to view page
-          navigateFn(routes.PIA_VIEW);
-        } else {
-          piaStateChangeHandler(true, 'isNextStepsSeenForDelegatedFlow');
-          piaStateChangeHandler(false, 'isNextStepsSeenForNonDelegatedFlow');
-        }
+    if (pia.hasAddedPiToDataElements === false) {
+      if (pia.isNextStepsSeenForDelegatedFlow) {
+        // redirect to view page
+        navigateFn(routes.PIA_VIEW);
       } else {
-        // if true or null
-        if (pia.isNextStepsSeenForNonDelegatedFlow) {
-          // redirect to next tab
-          navigateFn(routes.PIA_DISCLOSURE_EDIT);
-        } else {
-          piaStateChangeHandler(true, 'isNextStepsSeenForNonDelegatedFlow');
-          piaStateChangeHandler(false, 'isNextStepsSeenForDelegatedFlow');
-        }
+        piaStateChangeHandler(true, 'isNextStepsSeenForDelegatedFlow');
+        piaStateChangeHandler(false, 'isNextStepsSeenForNonDelegatedFlow');
       }
-    }, 1000);
+    } else {
+      // if true or null
+      if (pia.isNextStepsSeenForNonDelegatedFlow) {
+        // redirect to next tab
+        navigateFn(routes.PIA_DISCLOSURE_EDIT);
+      } else {
+        piaStateChangeHandler(true, 'isNextStepsSeenForNonDelegatedFlow');
+        piaStateChangeHandler(false, 'isNextStepsSeenForDelegatedFlow');
+      }
+    }
 
     /* This is to prevent this function being called for every update as
     this is only required to be called once when the component is mounted */

--- a/src/frontend/src/pages/PIAForm/index.tsx
+++ b/src/frontend/src/pages/PIAForm/index.tsx
@@ -358,41 +358,43 @@ const PIAFormPage = () => {
     const buttonValue = event.target.value;
     try {
       if (buttonValue === 'submitPiaIntake') {
-        await upsertAndUpdatePia({
+        const updatedPia = await upsertAndUpdatePia({
           status:
             pia?.hasAddedPiToDataElements === false
               ? PiaStatuses.MPO_REVIEW
               : PiaStatuses.INCOMPLETE,
         });
         if (
-          (pia?.id &&
-            pia?.isNextStepsSeenForNonDelegatedFlow === true &&
-            (pia?.hasAddedPiToDataElements === PIOptions[0].value ||
-              pia?.hasAddedPiToDataElements === PIOptions[2].value)) ||
-          (pia?.id &&
-            pia?.isNextStepsSeenForDelegatedFlow === true &&
-            pia?.hasAddedPiToDataElements === PIOptions[1].value)
+          (updatedPia?.id &&
+            updatedPia?.isNextStepsSeenForNonDelegatedFlow === true &&
+            (updatedPia?.hasAddedPiToDataElements === PIOptions[0].value ||
+              updatedPia?.hasAddedPiToDataElements === PIOptions[2].value)) ||
+          (updatedPia?.id &&
+            updatedPia?.isNextStepsSeenForDelegatedFlow === true &&
+            updatedPia?.hasAddedPiToDataElements === PIOptions[1].value)
         ) {
           navigate(
             buildDynamicPath(routes.PIA_VIEW, {
-              id: pia.id,
+              id: updatedPia.id,
             }),
           );
         } else {
           navigate(
             buildDynamicPath(routes.PIA_NEXT_STEPS_EDIT, {
-              id: pia.id,
-              title: pia.title,
+              id: updatedPia.id,
+              title: updatedPia.title,
             }),
           );
         }
       } else if (buttonValue === 'submitPiaForm') {
-        await upsertAndUpdatePia({ status: PiaStatuses.MPO_REVIEW });
+        const updatedPia = await upsertAndUpdatePia({
+          status: PiaStatuses.MPO_REVIEW,
+        });
 
-        if (pia?.id) {
+        if (updatedPia?.id) {
           navigate(
             buildDynamicPath(routes.PIA_VIEW, {
-              id: pia.id,
+              id: updatedPia.id,
             }),
           );
         }


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- BUGFIX: App goes to a continuous loading loop, if the user submits Intake before auto-submit kicks in

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Development Dependency Working Agreement
- [ ] My code DOES NOT include the importing of new dependencies into the DPIA ecosystem
- [ ] My code DOES include the importing of new dependencies into the DPIA ecosystem
**If new dependencies are being introduced to the DPIA ecosystem:**
- [ ] The functionality of the dependency drastically reduces code complexity and makes my changes more easily maintainable and readible 
- [ ] The dependency being introduced does not contain multiple layers of nested dependencies introducing maintainability complexity to the DPIA ecosystem

## Frontend Development Changes
- [ ] N/A
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to project documentation or diagrams that reflect my changes
- [ ] New and existing unit tests pass locally with my changes
- [ ] My code follows Airbnb React Style Guidelines

## API Development Changes
- [ ] N/A
- [ ] I have performed a self-review of my own code
- [ ] My code follows standards and practices outlined in the BC Government API Development Guidelines
- [ ] New and existing unit tests pass locally with my changes
- [ ] My changes includes Swagger documentation updates that reflect the changes I am introducing

## Definition of Done

![Definition of Done](https://raw.githubusercontent.com/bcgov/cirmo-dpia/main/.github/assets/DoD.jpg)
