### PR TITLE
UTOPIA-1015: "Filter By Status" field is cut off for Drafter role

### DIFF
--- a/src/frontend/src/components/public/PIAIntakeFilter/index.tsx
+++ b/src/frontend/src/components/public/PIAIntakeFilter/index.tsx
@@ -84,9 +84,9 @@ const PIAIntakeFilter = () => {
     <div className="w-100 d-lg-inline-flex text-nowrap align-items-center">
       <label>Filter by</label>
 
-      <div className="ms-lg-2 ms-xl-4">
+      <div className="ms-lg-2 ms-xl-4 w-100">
         <div className="row">
-          <div className="col-sm-6 col-md-3 pe-sm-0">
+          <div className="col-sm-6 col-md-3 pe-sm-0 pe-md-0">
             <Dropdown
               id="pia-status-select"
               value={filterByStatus}
@@ -97,8 +97,8 @@ const PIAIntakeFilter = () => {
             />
           </div>
 
-          <div className="col-sm-6 col-md-3 pt-4 pt-sm-0 pe-md-0">
-            {isMPORole() && (
+          {isMPORole() && (
+            <div className="col-sm-6 col-md-3 pt-4 pt-sm-0 pe-md-0">
               <Dropdown
                 id="ministry-select"
                 value={filterByMinistry}
@@ -107,11 +107,11 @@ const PIAIntakeFilter = () => {
                 changeHandler={handleMinistryChange}
                 required={false}
               />
-            )}
-          </div>
+            </div>
+          )}
 
-          <div className="col-sm-6 col-md-3 pt-4 pt-md-0 pe-sm-0">
-            {isMPORole() && (
+          {isMPORole() && (
+            <div className="col-sm-6 col-md-3 pt-4 pt-md-0 pe-sm-0">
               <Dropdown
                 id="drafter-filter-select"
                 value={filterPiaDrafterByCurrentUser}
@@ -120,9 +120,8 @@ const PIAIntakeFilter = () => {
                 changeHandler={handleDrafterFilterChange}
                 required={false}
               />
-            )}
-          </div>
-
+            </div>
+          )}
           <div className="col-sm-6 col-md-3 pt-4 pt-md-0 d-flex justify-content-start">
             <button
               className="bcgovbtn bcgovbtn__tertiary p-0 fw-bold"


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- UI for status filter renders correctly when user is a drafter-only role

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Updating Testing Framework(s)
- [ ] Version change

## How Has This Been Tested?

Checked dropdown UI size for each available role.

## Development Dependency Working Agreement
- [x] My code DOES NOT include the importing of new dependencies into the DPIA ecosystem
- [ ] My code DOES include the importing of new dependencies into the DPIA ecosystem
**If new dependencies are being introduced to the DPIA ecosystem:**
- [ ] The functionality of the dependency drastically reduces code complexity and makes my changes more easily maintainable and readible 
- [ ] The dependency being introduced does not contain multiple layers of nested dependencies introducing maintainability complexity to the DPIA ecosystem

## Frontend Development Changes
- [ ] N/A
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to project documentation or diagrams that reflect my changes
- [ ] New and existing unit tests pass locally with my changes
- [ ] My code follows Airbnb React Style Guidelines

## API Development Changes
- [x] N/A
- [ ] I have performed a self-review of my own code
- [ ] My code follows standards and practices outlined in the BC Government API Development Guidelines
- [ ] New and existing unit tests pass locally with my changes
- [ ] My changes includes Swagger documentation updates that reflect the changes I am introducing

## Definition of Done

![Definition of Done](https://raw.githubusercontent.com/bcgov/cirmo-dpia/main/.github/assets/DoD.jpg)
