### PR TITLE
[UTOPIA-1002] fix the banner display for cpo review status

### DIFF
--- a/src/frontend/src/pages/PIAForm/BannerStatus/index.tsx
+++ b/src/frontend/src/pages/PIAForm/BannerStatus/index.tsx
@@ -16,11 +16,13 @@ const BannerStatus = ({ pia }: IBannerStatusProps) => {
     return statusList[currentStatus].banner;
   };
 
-  return pia.status !== PiaStatuses.EDIT_IN_PROGRESS ? (
-    <div className="mb-5">
-      <Callout text={populateBanner()} bgWhite />
-    </div>
-  ) : null;
+  return (
+    populateBanner() && (
+      <div className="mb-5">
+        <Callout text={populateBanner()} bgWhite />
+      </div>
+    )
+  );
 };
 
 export default BannerStatus;


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- now the banner will display only the state machine will return a value otherwise it will hidde

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Updating Testing Framework(s)
- [ ] Version change

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Development Dependency Working Agreement
- [x] My code DOES NOT include the importing of new dependencies into the DPIA ecosystem
- [ ] My code DOES include the importing of new dependencies into the DPIA ecosystem
**If new dependencies are being introduced to the DPIA ecosystem:**
- [ ] The functionality of the dependency drastically reduces code complexity and makes my changes more easily maintainable and readible 
- [ ] The dependency being introduced does not contain multiple layers of nested dependencies introducing maintainability complexity to the DPIA ecosystem

## Frontend Development Changes
- [ ] N/A
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to project documentation or diagrams that reflect my changes
- [ ] New and existing unit tests pass locally with my changes
- [ ] My code follows Airbnb React Style Guidelines

## API Development Changes
- [x] N/A
- [ ] I have performed a self-review of my own code
- [ ] My code follows standards and practices outlined in the BC Government API Development Guidelines
- [ ] New and existing unit tests pass locally with my changes
- [ ] My changes includes Swagger documentation updates that reflect the changes I am introducing

## Definition of Done

![Definition of Done](https://raw.githubusercontent.com/bcgov/cirmo-dpia/main/.github/assets/DoD.jpg)
