### PR TITLE
[UTOPIA-991] make background picture only display on xxl size screen

### DIFF
--- a/src/frontend/src/pages/LandingPage/LandingPage.scss
+++ b/src/frontend/src/pages/LandingPage/LandingPage.scss
@@ -2,13 +2,13 @@
   display: flex;
   margin-top: calc($header-height);
   min-height: calc(100vh - $header-height);
-  @include breakpoint(0 map-get($grid-breakpoints, 'xl')) {
+  @include breakpoint(0 map-get($grid-breakpoints, 'xxl')) {
      flex-direction: column;
      justify-content: center;
      align-items: center;
     }
 
-  @include breakpoint(map-get($grid-breakpoints, 'xl')) {
+  @include breakpoint(map-get($grid-breakpoints, 'xxl')) {
     background-repeat: no-repeat;
     background-image: url(/src/assets/public_homepage/hero.svg);
     background-position: 90% 100%;

--- a/src/frontend/src/pages/LandingPage/LandingPage.tsx
+++ b/src/frontend/src/pages/LandingPage/LandingPage.tsx
@@ -20,7 +20,7 @@ function LandingPage() {
     <div>
       <section className="hero-section wrapper">
         <div data-cy="landing" className="hero-content">
-          <img className="d-xl-none" src={hero} alt="Fill out PIA" />
+          <img className="d-xxl-none" src={hero} alt="Fill out PIA" />
           <h1>Digital Privacy Impact Assessment (DPIA)</h1>
           <p>
             The Government of BC is creating a flagship Digital Privacy Impact


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- After discuss with the Designer, the new fix will make sure the background picture only show in xxl screen, otherwise display picture above the text

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Updating Testing Framework(s)
- [ ] Version change

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Development Dependency Working Agreement
- [x] My code DOES NOT include the importing of new dependencies into the DPIA ecosystem
- [ ] My code DOES include the importing of new dependencies into the DPIA ecosystem
**If new dependencies are being introduced to the DPIA ecosystem:**
- [ ] The functionality of the dependency drastically reduces code complexity and makes my changes more easily maintainable and readible 
- [ ] The dependency being introduced does not contain multiple layers of nested dependencies introducing maintainability complexity to the DPIA ecosystem

## Frontend Development Changes
- [ ] N/A
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to project documentation or diagrams that reflect my changes
- [ ] New and existing unit tests pass locally with my changes
- [ ] My code follows Airbnb React Style Guidelines

## API Development Changes
- [x] N/A
- [ ] I have performed a self-review of my own code
- [ ] My code follows standards and practices outlined in the BC Government API Development Guidelines
- [ ] New and existing unit tests pass locally with my changes
- [ ] My changes includes Swagger documentation updates that reflect the changes I am introducing

## Definition of Done

![Definition of Done](https://raw.githubusercontent.com/bcgov/cirmo-dpia/main/.github/assets/DoD.jpg)
