### PR TITLE
[UTOPIA-1162] remove banner text from edit in progress status

### DIFF
--- a/src/frontend/src/utils/status.ts
+++ b/src/frontend/src/utils/status.ts
@@ -177,7 +177,6 @@ export const statusList: StatusList = {
   EDIT_IN_PROGRESS: {
     title: 'EDIT IN PROGRESS',
     class: 'statusBlock__edit',
-    banner: 'test drafter',
     modal: {
       title: 'Change status to “Edit in progress”?',
       description:
@@ -187,7 +186,6 @@ export const statusList: StatusList = {
     },
     Privileges: {
       MPO: {
-        banner: 'test mpo',
         changeStatus: [
           {
             status: 'INCOMPLETE',


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- edit in progress status should not display any banner text,so remove the text from state machine 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Updating Testing Framework(s)
- [ ] Version change

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Development Dependency Working Agreement
- [x] My code DOES NOT include the importing of new dependencies into the DPIA ecosystem
- [ ] My code DOES include the importing of new dependencies into the DPIA ecosystem
**If new dependencies are being introduced to the DPIA ecosystem:**
- [ ] The functionality of the dependency drastically reduces code complexity and makes my changes more easily maintainable and readible 
- [ ] The dependency being introduced does not contain multiple layers of nested dependencies introducing maintainability complexity to the DPIA ecosystem

## Frontend Development Changes
- [ ] N/A
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to project documentation or diagrams that reflect my changes
- [ ] New and existing unit tests pass locally with my changes
- [ ] My code follows Airbnb React Style Guidelines

## API Development Changes
- [x] N/A
- [ ] I have performed a self-review of my own code
- [ ] My code follows standards and practices outlined in the BC Government API Development Guidelines
- [ ] New and existing unit tests pass locally with my changes
- [ ] My changes includes Swagger documentation updates that reflect the changes I am introducing

## Definition of Done

![Definition of Done](https://raw.githubusercontent.com/bcgov/cirmo-dpia/main/.github/assets/DoD.jpg)
