### PR TITLE
[UTOPIA-1170] Generate Invite Code endpoint implementation with migration and test cases

### DIFF
--- a/src/backend/src/app.module.ts
+++ b/src/backend/src/app.module.ts
@@ -16,6 +16,7 @@ import { ConfigurationModule } from './modules/configuration/configuration.modul
 import { PiaIntakeModule } from './modules/pia-intake/pia-intake.module';
 import { GCNotifyModule } from './modules/gcnotify/gcnotify.module';
 import { CommentsModule } from './modules/comments/comments.module';
+import { InvitesModule } from './modules/invites/invites.module';
 
 @Module({
   imports: [
@@ -32,6 +33,7 @@ import { CommentsModule } from './modules/comments/comments.module';
     PiaIntakeModule,
     GCNotifyModule,
     CommentsModule,
+    InvitesModule,
   ],
   controllers: [AppController],
   providers: [

--- a/src/backend/src/common/swagger.ts
+++ b/src/backend/src/common/swagger.ts
@@ -7,6 +7,7 @@ import { AuthModule } from 'src/modules/auth/auth.module';
 import { CommentsModule } from 'src/modules/comments/comments.module';
 import { ConfigurationModule } from 'src/modules/configuration/configuration.module';
 import { GCNotifyModule } from 'src/modules/gcnotify/gcnotify.module';
+import { InvitesModule } from 'src/modules/invites/invites.module';
 import { PiaIntakeModule } from 'src/modules/pia-intake/pia-intake.module';
 import { PpqModule } from 'src/modules/ppq/ppq.module';
 
@@ -36,6 +37,7 @@ export const SwaggerDocs = (app: INestApplication) => {
       PiaIntakeModule,
       GCNotifyModule,
       CommentsModule,
+      InvitesModule,
     ],
   });
 

--- a/src/backend/src/migrations/1686005634115-invites-entity.ts
+++ b/src/backend/src/migrations/1686005634115-invites-entity.ts
@@ -1,0 +1,27 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class InvitesEntity1686005634115 implements MigrationInterface {
+  name = 'InvitesEntity1686005634115';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TABLE "invites" ("id" SERIAL NOT NULL, "is_active" boolean NOT NULL DEFAULT true, "created_at" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(), "updated_at" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(), "created_by_guid" character varying NOT NULL, "created_by_username" character varying NOT NULL, "updated_by_guid" character varying NOT NULL, "updated_by_username" character varying NOT NULL, "code" uuid NOT NULL DEFAULT uuid_generate_v4(), "created_by_display_name" character varying NOT NULL, "pia_id" integer NOT NULL, CONSTRAINT "REL_e9fbb70df855a8f96b9ab658c3" UNIQUE ("pia_id"), CONSTRAINT "PK_aa52e96b44a714372f4dd31a0af" PRIMARY KEY ("id"))`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_e9fbb70df855a8f96b9ab658c3" ON "invites" ("pia_id") `,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "invites" ADD CONSTRAINT "FK_e9fbb70df855a8f96b9ab658c30" FOREIGN KEY ("pia_id") REFERENCES "pia-intake"("id") ON DELETE CASCADE ON UPDATE CASCADE`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "invites" DROP CONSTRAINT "FK_e9fbb70df855a8f96b9ab658c30"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_e9fbb70df855a8f96b9ab658c3"`,
+    );
+    await queryRunner.query(`DROP TABLE "invites"`);
+  }
+}

--- a/src/backend/src/modules/comments/comments.service.ts
+++ b/src/backend/src/modules/comments/comments.service.ts
@@ -31,15 +31,6 @@ export class CommentsService {
     private readonly piaService: PiaIntakeService,
   ) {}
 
-  async validatePiaAccess(
-    piaId: number,
-    user: KeycloakUser,
-    userRoles: Array<RolesEnum>,
-  ) {
-    // this service method will fetch pia and validate user access
-    await this.piaService.findOneById(piaId, user, userRoles);
-  }
-
   async findOneBy(
     where: FindOptionsWhere<CommentEntity>,
   ): Promise<CommentEntity> {
@@ -61,7 +52,11 @@ export class CommentsService {
     userRoles: Array<RolesEnum>,
   ): Promise<CommentRO> {
     // validate access to PIA. Throw error if not
-    await this.validatePiaAccess(createCommentDto.piaId, user, userRoles);
+    await this.piaService.validatePiaAccess(
+      createCommentDto.piaId,
+      user,
+      userRoles,
+    );
 
     // extract user input dto
     const { piaId, path, text } = createCommentDto;
@@ -93,7 +88,7 @@ export class CommentsService {
     userRoles: Array<RolesEnum>,
   ): Promise<Array<CommentRO>> {
     // validate access to PIA. Throw error if not
-    await this.validatePiaAccess(piaId, user, userRoles);
+    await this.piaService.validatePiaAccess(piaId, user, userRoles);
 
     // fetch comments for the pia
     const comments: CommentEntity[] = await this.commentRepository.find({
@@ -116,7 +111,7 @@ export class CommentsService {
     userRoles: Array<RolesEnum>,
   ): Promise<Partial<CommentsCountRO>> {
     // validate access to PIA. Throw error if not
-    await this.validatePiaAccess(piaId, user, userRoles);
+    await this.piaService.validatePiaAccess(piaId, user, userRoles);
 
     // fetch comments for the pia grouped by path
     const commentsCount: Array<CommentsCountDbRO> = await this.commentRepository
@@ -145,7 +140,7 @@ export class CommentsService {
     }
 
     // validate access to PIA. Throw error if not
-    await this.validatePiaAccess(comment.piaId, user, userRoles);
+    await this.piaService.validatePiaAccess(comment.piaId, user, userRoles);
 
     // throw error if comment already deleted
     if (comment.isActive === false) {

--- a/src/backend/src/modules/invites/dto/generate-invite.dto.ts
+++ b/src/backend/src/modules/invites/dto/generate-invite.dto.ts
@@ -1,0 +1,12 @@
+import { IsNumber } from '@nestjs/class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class GenerateInviteDto {
+  @IsNumber()
+  @ApiProperty({
+    type: Number,
+    required: true,
+    example: 1,
+  })
+  piaId: number;
+}

--- a/src/backend/src/modules/invites/entities/invite.entity.ts
+++ b/src/backend/src/modules/invites/entities/invite.entity.ts
@@ -1,0 +1,40 @@
+import {
+  Column,
+  Entity,
+  Generated,
+  Index,
+  JoinColumn,
+  OneToOne,
+  RelationId,
+} from 'typeorm';
+import { BaseEntity } from 'src/common/entities/base.entity';
+import { PiaIntakeEntity } from 'src/modules/pia-intake/entities/pia-intake.entity';
+
+@Entity('invites')
+export class InviteEntity extends BaseEntity {
+  @OneToOne(() => PiaIntakeEntity, {
+    nullable: false,
+    onDelete: 'CASCADE',
+    onUpdate: 'CASCADE',
+  })
+  @JoinColumn({ name: 'pia_id' })
+  @Index()
+  pia: PiaIntakeEntity;
+
+  @RelationId((invite: InviteEntity) => invite.pia)
+  piaId: number;
+
+  // invite code
+  @Column({
+    name: 'code',
+    type: 'uuid',
+  })
+  @Generated('uuid')
+  code: string;
+
+  @Column({
+    name: 'created_by_display_name',
+    nullable: false,
+  })
+  createdByDisplayName: string;
+}

--- a/src/backend/src/modules/invites/invites.controller.ts
+++ b/src/backend/src/modules/invites/invites.controller.ts
@@ -1,0 +1,51 @@
+import { Controller, Post, Body, Req } from '@nestjs/common';
+import { InvitesService } from './invites.service';
+import { GenerateInviteDto } from './dto/generate-invite.dto';
+import { IRequest } from 'src/common/interfaces/request.interface';
+import {
+  ApiBearerAuth,
+  ApiForbiddenResponse,
+  ApiGoneResponse,
+  ApiNotFoundResponse,
+  ApiOkResponse,
+  ApiOperation,
+  ApiTags,
+} from '@nestjs/swagger';
+import { InviteRO } from './ro/get-invite.ro';
+
+@Controller('invite')
+@ApiTags('invite')
+@ApiBearerAuth()
+export class InvitesController {
+  constructor(private readonly invitesService: InvitesService) {}
+
+  @Post()
+  @ApiOperation({
+    description: 'Generate Invite code for the pia',
+  })
+  @ApiOkResponse({
+    description: 'Successfully generated or fetched the pia invite code',
+  })
+  @ApiForbiddenResponse({
+    description:
+      'Failed to generate or fetch pia invite code: User lacks permission to access the PIA',
+  })
+  @ApiNotFoundResponse({
+    description:
+      'Failed to generate or fetch pia invite code: PIA for the id provided not found',
+  })
+  @ApiGoneResponse({
+    description:
+      'Failed to generate or fetch pia invite code: PIA is not active anymore',
+  })
+  generate(
+    @Body() generateInviteDto: GenerateInviteDto,
+    @Req() req: IRequest,
+  ): Promise<InviteRO> {
+    return this.invitesService.generate(
+      generateInviteDto,
+      req.user,
+      req.userRoles,
+    );
+  }
+}

--- a/src/backend/src/modules/invites/invites.module.ts
+++ b/src/backend/src/modules/invites/invites.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { InvitesService } from './invites.service';
+import { InvitesController } from './invites.controller';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { InviteEntity } from './entities/invite.entity';
+import { PiaIntakeModule } from '../pia-intake/pia-intake.module';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([InviteEntity]), PiaIntakeModule],
+  controllers: [InvitesController],
+  providers: [InvitesService],
+})
+export class InvitesModule {}

--- a/src/backend/src/modules/invites/invites.service.ts
+++ b/src/backend/src/modules/invites/invites.service.ts
@@ -1,0 +1,65 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { RolesEnum } from 'src/common/enums/roles.enum';
+import { Repository } from 'typeorm';
+import { KeycloakUser } from '../auth/keycloak-user.model';
+import { PiaIntakeService } from '../pia-intake/pia-intake.service';
+import { GenerateInviteDto } from './dto/generate-invite.dto';
+import { InviteEntity } from './entities/invite.entity';
+import { getFormattedInvite, InviteRO } from './ro/get-invite.ro';
+
+@Injectable()
+export class InvitesService {
+  constructor(
+    @InjectRepository(InviteEntity)
+    private inviteRepository: Repository<InviteEntity>,
+    private readonly piaService: PiaIntakeService,
+  ) {}
+
+  async generate(
+    generateInviteDto: GenerateInviteDto,
+    user: KeycloakUser,
+    userRoles: Array<RolesEnum>,
+  ): Promise<InviteRO> {
+    // validate access to PIA. Throw error if not
+    await this.piaService.validatePiaAccess(
+      generateInviteDto.piaId,
+      user,
+      userRoles,
+    );
+
+    // extract user input dto
+    const { piaId } = generateInviteDto;
+
+    // return the invite code if already exists
+    const existingInvite = await this.inviteRepository.findOne({
+      relations: [],
+      where: {
+        pia: {
+          id: piaId,
+        },
+      },
+    });
+
+    // return the formatted invite code if already exists
+    if (existingInvite) {
+      return getFormattedInvite(existingInvite);
+    }
+
+    // else, fetch pia entity and create the invite code
+    const pia = await this.piaService.findOneBy({ id: piaId });
+
+    // create the invite resource
+    const invite: InviteEntity = await this.inviteRepository.save({
+      pia,
+      createdByGuid: user.idir_user_guid,
+      createdByUsername: user.idir_username,
+      updatedByGuid: user.idir_user_guid,
+      updatedByUsername: user.idir_username,
+      createdByDisplayName: user.display_name,
+    });
+
+    // return formatted object
+    return getFormattedInvite(invite);
+  }
+}

--- a/src/backend/src/modules/invites/ro/get-invite.ro.ts
+++ b/src/backend/src/modules/invites/ro/get-invite.ro.ts
@@ -1,0 +1,24 @@
+import {
+  ExcludeBaseSelection,
+  omitBaseKeys,
+} from 'src/common/helpers/base-helper';
+import { InviteEntity } from '../entities/invite.entity';
+
+export const excludeInviteKeys = {
+  pia: true,
+  id: true,
+  isActive: true,
+  createdAt: true,
+  updatedAt: true,
+  createdByGuid: true,
+  createdByDisplayName: true,
+};
+
+export type InviteRO = Omit<
+  InviteEntity,
+  keyof ExcludeBaseSelection | keyof typeof excludeInviteKeys
+>;
+
+export const getFormattedInvite = (invite: InviteEntity) => {
+  return omitBaseKeys<InviteRO>(invite, Object.keys(excludeInviteKeys));
+};

--- a/src/backend/src/modules/pia-intake/pia-intake.service.ts
+++ b/src/backend/src/modules/pia-intake/pia-intake.service.ts
@@ -528,4 +528,14 @@ export class PiaIntakeService {
 
     // ... space for future validators, as needed
   }
+
+  // wrapper | convenient method that validates PIA access
+  async validatePiaAccess(
+    piaId: number,
+    user: KeycloakUser,
+    userRoles: Array<RolesEnum>,
+  ) {
+    // this method will fetch pia and validate user access
+    await this.findOneById(piaId, user, userRoles);
+  }
 }

--- a/src/backend/test/unit/comments/comments.service.spec.ts
+++ b/src/backend/test/unit/comments/comments.service.spec.ts
@@ -102,7 +102,7 @@ describe('CommentsService', () => {
 
       const expectedResult = { ...commentROMock };
 
-      commentsService.validatePiaAccess = jest.fn(async () => null);
+      piaService.validatePiaAccess = jest.fn(async () => null);
 
       piaService.findOneBy = jest.fn(async () => {
         delay(10);
@@ -120,7 +120,7 @@ describe('CommentsService', () => {
         userRoles,
       );
 
-      expect(commentsService.validatePiaAccess).toHaveBeenCalledWith(
+      expect(piaService.validatePiaAccess).toHaveBeenCalledWith(
         createCommentDto.piaId,
         user,
         userRoles,
@@ -175,7 +175,7 @@ describe('CommentsService', () => {
 
       const expectedResult = [...findCommentsROMock];
 
-      commentsService.validatePiaAccess = jest.fn(async () => null);
+      piaService.validatePiaAccess = jest.fn(async () => null);
 
       commentRepository.find = jest.fn(async () => {
         delay(10);
@@ -189,7 +189,7 @@ describe('CommentsService', () => {
         userRoles,
       );
 
-      expect(commentsService.validatePiaAccess).toHaveBeenCalledWith(
+      expect(piaService.validatePiaAccess).toHaveBeenCalledWith(
         piaId,
         user,
         userRoles,
@@ -235,7 +235,7 @@ describe('CommentsService', () => {
 
       const expectedResult = { ...commentsCountROMock };
 
-      commentsService.validatePiaAccess = jest.fn(async () => null);
+      piaService.validatePiaAccess = jest.fn(async () => null);
 
       commentRepository.createQueryBuilder = jest.fn(() => {
         return {
@@ -267,7 +267,7 @@ describe('CommentsService', () => {
         userRoles,
       );
 
-      expect(commentsService.validatePiaAccess).toHaveBeenCalledWith(
+      expect(piaService.validatePiaAccess).toHaveBeenCalledWith(
         piaId,
         user,
         userRoles,
@@ -325,14 +325,14 @@ describe('CommentsService', () => {
         isActive: false,
       }));
 
-      commentsService.validatePiaAccess = jest.fn(async () => null);
+      piaService.validatePiaAccess = jest.fn(async () => null);
 
       await expect(commentsService.remove(id, user, userRoles)).rejects.toThrow(
         new BadRequestException('Comment already deleted'),
       );
 
       expect(commentsService.findOneBy).toHaveBeenCalledWith({ id });
-      expect(commentsService.validatePiaAccess).toHaveBeenCalledWith(
+      expect(piaService.validatePiaAccess).toHaveBeenCalledWith(
         commentEntityMock.piaId,
         user,
         userRoles,
@@ -349,7 +349,7 @@ describe('CommentsService', () => {
         ...commentEntityMock,
       }));
 
-      commentsService.validatePiaAccess = jest.fn(async () => null);
+      piaService.validatePiaAccess = jest.fn(async () => null);
 
       commentRepository.save = jest.fn(async () => {
         delay(10);
@@ -359,7 +359,7 @@ describe('CommentsService', () => {
       const result = await commentsService.remove(id, user, userRoles);
 
       expect(commentsService.findOneBy).toHaveBeenCalledWith({ id });
-      expect(commentsService.validatePiaAccess).toHaveBeenCalledWith(
+      expect(piaService.validatePiaAccess).toHaveBeenCalledWith(
         commentEntityMock.piaId,
         user,
         userRoles,
@@ -405,36 +405,6 @@ describe('CommentsService', () => {
       expect(result).toBe(
         `This is a resolve method yet to be developed for comment ${id}`,
       );
-    });
-  });
-
-  /**
-   * @method validatePiaAccess
-   */
-  describe('`validatePiaAccess', () => {
-    /**
-     * This test validates that the method forwards the correct data to the piaService method
-     *
-     * @Input
-     *   - piaId: number
-     *   - user info mock
-     *
-     * @Output
-     *   - void
-     */
-    it('succeeds forwarding correct data to the pia-service method', async () => {
-      const piaId = 101;
-      const user: KeycloakUser = { ...keycloakUserMock };
-      const userRoles: Array<RolesEnum> = [];
-
-      piaService.findOneById = jest.fn(async () => {
-        delay(10);
-        return { ...piaIntakeEntityMock };
-      });
-
-      await commentsService.validatePiaAccess(piaId, user, userRoles);
-
-      expect(piaService.findOneById).toBeCalledWith(piaId, user, userRoles);
     });
   });
 

--- a/src/backend/test/unit/invites/invites.controller.spec.ts
+++ b/src/backend/test/unit/invites/invites.controller.spec.ts
@@ -1,0 +1,79 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { GenerateInviteDto } from 'src/modules/invites/dto/generate-invite.dto';
+import { InviteEntity } from 'src/modules/invites/entities/invite.entity';
+import { InvitesController } from 'src/modules/invites/invites.controller';
+import { InvitesService } from 'src/modules/invites/invites.service';
+import { keycloakUserMock } from 'test/util/mocks/data/auth.mock';
+import {
+  generateInviteDtoMock,
+  generateInviteROMock,
+} from 'test/util/mocks/data/invites.mock';
+import { repositoryMock } from 'test/util/mocks/repository/repository.mock';
+import { invitesServiceMock } from 'test/util/mocks/services/invites.service.mock';
+import { delay } from 'test/util/testUtils';
+
+describe('InvitesController', () => {
+  let controller: InvitesController;
+  let service: InvitesService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [InvitesController],
+      providers: [
+        {
+          provide: InvitesService,
+          useValue: invitesServiceMock,
+        },
+        {
+          provide: getRepositoryToken(InviteEntity),
+          useValue: { ...repositoryMock },
+        },
+      ],
+    }).compile();
+
+    controller = module.get<InvitesController>(InvitesController);
+    service = module.get<InvitesService>(InvitesService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+    expect(service).toBeDefined();
+  });
+
+  /**
+   * @method generate
+   */
+  describe('`generate` method', () => {
+    /**
+     * @Description
+     * This test suite validates that the generate method is called with correct parameters
+     */
+    it('succeeds calling generate service method with correct params', async () => {
+      const generateInviteDto: GenerateInviteDto = { ...generateInviteDtoMock };
+      const mockReq: any = {
+        user: { ...keycloakUserMock },
+        userRoles: [],
+      };
+
+      service.generate = jest.fn(async () => {
+        delay(10);
+        return generateInviteROMock;
+      });
+
+      const result = await controller.generate(generateInviteDto, mockReq);
+
+      expect(service.generate).toHaveBeenCalledWith(
+        generateInviteDto,
+        mockReq.user,
+        mockReq.userRoles,
+      );
+
+      expect(result).toBe(generateInviteROMock);
+    });
+  });
+});

--- a/src/backend/test/unit/invites/invites.service.spec.ts
+++ b/src/backend/test/unit/invites/invites.service.spec.ts
@@ -1,0 +1,151 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { AuthModule } from 'src/modules/auth/auth.module';
+import { KeycloakUser } from 'src/modules/auth/keycloak-user.model';
+import { GenerateInviteDto } from 'src/modules/invites/dto/generate-invite.dto';
+import { InviteEntity } from 'src/modules/invites/entities/invite.entity';
+import { InvitesController } from 'src/modules/invites/invites.controller';
+import { InvitesService } from 'src/modules/invites/invites.service';
+import { PiaIntakeService } from 'src/modules/pia-intake/pia-intake.service';
+import { keycloakUserMock } from 'test/util/mocks/data/auth.mock';
+import {
+  generateInviteDtoMock,
+  generateInviteROMock,
+  inviteEntityMock,
+} from 'test/util/mocks/data/invites.mock';
+import { piaIntakeEntityMock } from 'test/util/mocks/data/pia-intake.mock';
+import { repositoryMock } from 'test/util/mocks/repository/repository.mock';
+import { piaIntakeServiceMock } from 'test/util/mocks/services/pia-intake.service.mock';
+
+describe('InvitesService', () => {
+  let invitesService: InvitesService;
+  let piaService: PiaIntakeService;
+  let inviteRepository;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      imports: [AuthModule],
+      controllers: [InvitesController],
+      providers: [
+        InvitesService,
+        {
+          provide: PiaIntakeService,
+          useValue: piaIntakeServiceMock,
+        },
+        {
+          provide: getRepositoryToken(InviteEntity),
+          useValue: { ...repositoryMock },
+        },
+      ],
+    }).compile();
+
+    invitesService = module.get<InvitesService>(InvitesService);
+    piaService = module.get<PiaIntakeService>(PiaIntakeService);
+    inviteRepository = module.get(getRepositoryToken(InviteEntity));
+  });
+
+  it('should be defined', () => {
+    expect(invitesService).toBeDefined();
+    expect(piaService).toBeDefined();
+  });
+
+  /**
+   * @Description
+   * This test suite validates that the invite code is not generated again, if already present for the PIA
+   */
+  it('succeeds returning the already generated invite code', async () => {
+    const generateInviteDto: GenerateInviteDto = { ...generateInviteDtoMock };
+    const mockReq: any = {
+      user: { ...keycloakUserMock },
+      userRoles: [],
+    };
+
+    const expectedResult = { ...generateInviteROMock };
+
+    inviteRepository.findOne = jest.fn(async () => inviteEntityMock);
+
+    const result = await invitesService.generate(
+      generateInviteDto,
+      mockReq.user,
+      mockReq.userRoles,
+    );
+
+    expect(piaService.validatePiaAccess).toHaveBeenCalledWith(
+      generateInviteDto.piaId,
+      mockReq.user,
+      mockReq.userRoles,
+    );
+
+    expect(inviteRepository.findOne).toHaveBeenCalledWith({
+      relations: [],
+      where: {
+        pia: {
+          id: generateInviteDto.piaId,
+        },
+      },
+    });
+
+    expect(piaService.findOneBy).not.toHaveBeenCalled();
+    expect(inviteRepository.save).not.toHaveBeenCalled();
+    expect(result).toEqual(expectedResult);
+  });
+
+  /**
+   * @Description
+   * This test suite validates that the invite code is generated and returned to the user, if not already generated
+   */
+  it('succeeds generating a new invite code if not available', async () => {
+    const generateInviteDto: GenerateInviteDto = { ...generateInviteDtoMock };
+    const user: KeycloakUser = { ...keycloakUserMock };
+    const userRoles = [];
+
+    const mockReq: any = {
+      user,
+      userRoles,
+    };
+
+    const expectedResult = { ...generateInviteROMock };
+
+    // repo returns null - no invite code available for the piaId provided
+    inviteRepository.findOne = jest.fn(async () => null);
+
+    piaService.findOneBy = jest.fn(async () => ({ ...piaIntakeEntityMock }));
+
+    inviteRepository.save = jest.fn(async () => ({ ...inviteEntityMock }));
+
+    const result = await invitesService.generate(
+      generateInviteDto,
+      mockReq.user,
+      mockReq.userRoles,
+    );
+
+    expect(piaService.validatePiaAccess).toHaveBeenCalledWith(
+      generateInviteDto.piaId,
+      mockReq.user,
+      mockReq.userRoles,
+    );
+
+    expect(inviteRepository.findOne).toHaveBeenCalledWith({
+      relations: [],
+      where: {
+        pia: {
+          id: generateInviteDto.piaId,
+        },
+      },
+    });
+
+    expect(piaService.findOneBy).toHaveBeenCalledWith({
+      id: generateInviteDto.piaId,
+    });
+    expect(inviteRepository.save).toHaveBeenCalledWith({
+      pia: { ...piaIntakeEntityMock },
+      createdByGuid: user.idir_user_guid,
+      createdByUsername: user.idir_username,
+      updatedByGuid: user.idir_user_guid,
+      updatedByUsername: user.idir_username,
+      createdByDisplayName: user.display_name,
+    });
+
+    expect(result).toEqual(expectedResult);
+  });
+});

--- a/src/backend/test/unit/pia-intake/pia-intake.service.spec.ts
+++ b/src/backend/test/unit/pia-intake/pia-intake.service.spec.ts
@@ -2017,4 +2017,34 @@ describe('PiaIntakeService', () => {
       expect(result).toEqual(piaIntakeEntityMock);
     });
   });
+
+  /**
+   * @method validatePiaAccess
+   */
+  describe('`validatePiaAccess', () => {
+    /**
+     * This test validates that the method calls the findOneById method to validate access
+     *
+     * @Input
+     *   - piaId: number
+     *   - user info mock
+     *
+     * @Output
+     *   - void
+     */
+    it('succeeds calling findOneById method', async () => {
+      const piaId = 101;
+      const user: KeycloakUser = { ...keycloakUserMock };
+      const userRoles: Array<RolesEnum> = [];
+
+      service.findOneById = jest.fn(async () => {
+        delay(10);
+        return { ...piaIntakeEntityMock };
+      });
+
+      await service.validatePiaAccess(piaId, user, userRoles);
+
+      expect(service.findOneById).toBeCalledWith(piaId, user, userRoles);
+    });
+  });
 });

--- a/src/backend/test/unit/pia-intake/pia-intake.service.spec.ts
+++ b/src/backend/test/unit/pia-intake/pia-intake.service.spec.ts
@@ -1862,7 +1862,7 @@ describe('PiaIntakeService', () => {
       };
 
       expect(shortDateSpy).toHaveBeenCalledTimes(1);
-      expect(shortDateSpy).toHaveBeenCalledWith(getPiaIntakeRO.createdAt);
+      expect(shortDateSpy).toHaveBeenCalledWith(getPiaIntakeRO.updatedAt);
 
       expect(markedParseSpy).toHaveBeenCalledTimes(4);
 

--- a/src/backend/test/util/mocks/data/invites.mock.ts
+++ b/src/backend/test/util/mocks/data/invites.mock.ts
@@ -1,0 +1,28 @@
+import { GenerateInviteDto } from 'src/modules/invites/dto/generate-invite.dto';
+import { InviteEntity } from 'src/modules/invites/entities/invite.entity';
+import { InviteRO } from 'src/modules/invites/ro/get-invite.ro';
+import { piaIntakeEntityMock } from './pia-intake.mock';
+
+export const generateInviteDtoMock: GenerateInviteDto = {
+  piaId: 101,
+};
+
+export const generateInviteROMock: InviteRO = {
+  piaId: 101,
+  code: '39581485-6d75-4f31-a739-4919d6de0ec9',
+};
+
+export const inviteEntityMock: InviteEntity = {
+  id: 1,
+  isActive: true,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  createdByGuid: 'DBB6707E34A641FC8ABEBF07B8145F60',
+  createdByUsername: 'KARORA',
+  updatedByGuid: 'DBB6707E34A641FC8ABEBF07B8145F60',
+  updatedByUsername: 'KARORA',
+  code: '39581485-6d75-4f31-a739-4919d6de0ec9',
+  createdByDisplayName: 'Arora, Kushal CITZ:EX',
+  piaId: 101,
+  pia: { ...piaIntakeEntityMock },
+};

--- a/src/backend/test/util/mocks/services/comments.service.mock.ts
+++ b/src/backend/test/util/mocks/services/comments.service.mock.ts
@@ -5,5 +5,4 @@ export const commentsServiceMock = {
   remove: jest.fn(),
   resolve: jest.fn(),
   findOneBy: jest.fn(),
-  validatePiaAccess: jest.fn(),
 };

--- a/src/backend/test/util/mocks/services/invites.service.mock.ts
+++ b/src/backend/test/util/mocks/services/invites.service.mock.ts
@@ -1,0 +1,3 @@
+export const invitesServiceMock = {
+  generate: jest.fn(),
+};

--- a/src/backend/test/util/mocks/services/pia-intake.service.mock.ts
+++ b/src/backend/test/util/mocks/services/pia-intake.service.mock.ts
@@ -1,6 +1,7 @@
 export const piaIntakeServiceMock = {
   create: jest.fn(),
   findAll: jest.fn(),
+  findOneBy: jest.fn(),
   findOneById: jest.fn(),
   downloadPiaIntakeResultPdf: jest.fn(),
   validatePiaAccess: jest.fn(),

--- a/src/backend/test/util/mocks/services/pia-intake.service.mock.ts
+++ b/src/backend/test/util/mocks/services/pia-intake.service.mock.ts
@@ -3,4 +3,5 @@ export const piaIntakeServiceMock = {
   findAll: jest.fn(),
   findOneById: jest.fn(),
   downloadPiaIntakeResultPdf: jest.fn(),
+  validatePiaAccess: jest.fn(),
 };


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- moved validatePiaAccess method to PiaService
- Generate Invite Code endpoint implementation
- Migration to create `invite` table and constraints
- Relevant test cases

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Updating Testing Framework(s)
- [ ] Version change

## How Has This Been Tested?

You can use swagger to test this PR
1. See if you're able to generate the invite code using the new /invite endpoint
2. Validate that the code is not regenerated, if already done one
You can also comment or validate if you swagger docs is intuitive enough to understand.

## Development Dependency Working Agreement
- [x] My code DOES NOT include the importing of new dependencies into the DPIA ecosystem
- [ ] My code DOES include the importing of new dependencies into the DPIA ecosystem
**If new dependencies are being introduced to the DPIA ecosystem:**
- [ ] The functionality of the dependency drastically reduces code complexity and makes my changes more easily maintainable and readible 
- [ ] The dependency being introduced does not contain multiple layers of nested dependencies introducing maintainability complexity to the DPIA ecosystem

## Frontend Development Changes
- [x] N/A
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to project documentation or diagrams that reflect my changes
- [ ] New and existing unit tests pass locally with my changes
- [ ] My code follows Airbnb React Style Guidelines

## API Development Changes
- [ ] N/A
- [x] I have performed a self-review of my own code
- [x] My code follows standards and practices outlined in the BC Government API Development Guidelines
- [x] New and existing unit tests pass locally with my changes
- [x] My changes includes Swagger documentation updates that reflect the changes I am introducing

## Definition of Done

![Definition of Done](https://raw.githubusercontent.com/bcgov/cirmo-dpia/main/.github/assets/DoD.jpg)
