### PR TITLE
[UTOPIA-1170] [Build fix attempt #2] moved UUID generator from Db to API

### DIFF
--- a/src/backend/src/migrations/1686005634115-invites-entity.ts
+++ b/src/backend/src/migrations/1686005634115-invites-entity.ts
@@ -4,10 +4,8 @@ export class InvitesEntity1686005634115 implements MigrationInterface {
   name = 'InvitesEntity1686005634115';
 
   public async up(queryRunner: QueryRunner): Promise<void> {
-    await queryRunner.query(`CREATE EXTENSION IF NOT EXISTS "uuid-ossp";`);
-
     await queryRunner.query(
-      `CREATE TABLE "invites" ("id" SERIAL NOT NULL, "is_active" boolean NOT NULL DEFAULT true, "created_at" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(), "updated_at" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(), "created_by_guid" character varying NOT NULL, "created_by_username" character varying NOT NULL, "updated_by_guid" character varying NOT NULL, "updated_by_username" character varying NOT NULL, "code" uuid NOT NULL DEFAULT uuid_generate_v4(), "created_by_display_name" character varying NOT NULL, "pia_id" integer NOT NULL, CONSTRAINT "REL_e9fbb70df855a8f96b9ab658c3" UNIQUE ("pia_id"), CONSTRAINT "PK_aa52e96b44a714372f4dd31a0af" PRIMARY KEY ("id"))`,
+      `CREATE TABLE "invites" ("id" SERIAL NOT NULL, "is_active" boolean NOT NULL DEFAULT true, "created_at" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(), "updated_at" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(), "created_by_guid" character varying NOT NULL, "created_by_username" character varying NOT NULL, "updated_by_guid" character varying NOT NULL, "updated_by_username" character varying NOT NULL, "code" character varying NOT NULL, "created_by_display_name" character varying NOT NULL, "pia_id" integer NOT NULL, CONSTRAINT "REL_e9fbb70df855a8f96b9ab658c3" UNIQUE ("pia_id"), CONSTRAINT "PK_aa52e96b44a714372f4dd31a0af" PRIMARY KEY ("id"))`,
     );
     await queryRunner.query(
       `CREATE INDEX "IDX_e9fbb70df855a8f96b9ab658c3" ON "invites" ("pia_id") `,

--- a/src/backend/src/modules/invites/entities/invite.entity.ts
+++ b/src/backend/src/modules/invites/entities/invite.entity.ts
@@ -1,7 +1,6 @@
 import {
   Column,
   Entity,
-  Generated,
   Index,
   JoinColumn,
   OneToOne,
@@ -27,9 +26,8 @@ export class InviteEntity extends BaseEntity {
   // invite code
   @Column({
     name: 'code',
-    type: 'uuid',
+    nullable: false,
   })
-  @Generated('uuid')
   code: string;
 
   @Column({

--- a/src/backend/src/modules/invites/invites.service.ts
+++ b/src/backend/src/modules/invites/invites.service.ts
@@ -7,6 +7,7 @@ import { PiaIntakeService } from '../pia-intake/pia-intake.service';
 import { GenerateInviteDto } from './dto/generate-invite.dto';
 import { InviteEntity } from './entities/invite.entity';
 import { getFormattedInvite, InviteRO } from './ro/get-invite.ro';
+import { randomUUID } from 'crypto';
 
 @Injectable()
 export class InvitesService {
@@ -51,9 +52,13 @@ export class InvitesService {
     // else, fetch pia entity and create the invite code
     const pia = await this.piaService.findOneBy({ id: piaId });
 
+    // create Invite code using the inbuilt crypto module that uses a UUID v4 generator
+    const inviteCode = randomUUID();
+
     // create the invite resource
     const invite: InviteEntity = await this.inviteRepository.save({
       pia,
+      code: inviteCode,
       createdByGuid: user.idir_user_guid,
       createdByUsername: user.idir_username,
       updatedByGuid: user.idir_user_guid,

--- a/src/backend/test/unit/invites/invites.service.spec.ts
+++ b/src/backend/test/unit/invites/invites.service.spec.ts
@@ -11,16 +11,22 @@ import { keycloakUserMock } from 'test/util/mocks/data/auth.mock';
 import {
   generateInviteDtoMock,
   generateInviteROMock,
+  inviteCodeMock,
   inviteEntityMock,
 } from 'test/util/mocks/data/invites.mock';
 import { piaIntakeEntityMock } from 'test/util/mocks/data/pia-intake.mock';
 import { repositoryMock } from 'test/util/mocks/repository/repository.mock';
 import { piaIntakeServiceMock } from 'test/util/mocks/services/pia-intake.service.mock';
+import * as crypto from 'crypto';
 
 describe('InvitesService', () => {
   let invitesService: InvitesService;
   let piaService: PiaIntakeService;
   let inviteRepository;
+
+  const randomUUIDSpy = jest
+    .spyOn(crypto, 'randomUUID')
+    .mockImplementation(() => inviteCodeMock);
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -42,6 +48,8 @@ describe('InvitesService', () => {
     invitesService = module.get<InvitesService>(InvitesService);
     piaService = module.get<PiaIntakeService>(PiaIntakeService);
     inviteRepository = module.get(getRepositoryToken(InviteEntity));
+
+    randomUUIDSpy.mockClear();
   });
 
   it('should be defined', () => {
@@ -86,6 +94,7 @@ describe('InvitesService', () => {
     });
 
     expect(piaService.findOneBy).not.toHaveBeenCalled();
+    expect(randomUUIDSpy).not.toHaveBeenCalled();
     expect(inviteRepository.save).not.toHaveBeenCalled();
     expect(result).toEqual(expectedResult);
   });
@@ -137,8 +146,12 @@ describe('InvitesService', () => {
     expect(piaService.findOneBy).toHaveBeenCalledWith({
       id: generateInviteDto.piaId,
     });
+
+    expect(randomUUIDSpy).toHaveBeenCalled();
+
     expect(inviteRepository.save).toHaveBeenCalledWith({
       pia: { ...piaIntakeEntityMock },
+      code: inviteCodeMock,
       createdByGuid: user.idir_user_guid,
       createdByUsername: user.idir_username,
       updatedByGuid: user.idir_user_guid,

--- a/src/backend/test/util/mocks/data/invites.mock.ts
+++ b/src/backend/test/util/mocks/data/invites.mock.ts
@@ -3,13 +3,15 @@ import { InviteEntity } from 'src/modules/invites/entities/invite.entity';
 import { InviteRO } from 'src/modules/invites/ro/get-invite.ro';
 import { piaIntakeEntityMock } from './pia-intake.mock';
 
+export const inviteCodeMock = '39581485-6d75-4f31-a739-4919d6de0ec9';
+
 export const generateInviteDtoMock: GenerateInviteDto = {
   piaId: 101,
 };
 
 export const generateInviteROMock: InviteRO = {
   piaId: 101,
-  code: '39581485-6d75-4f31-a739-4919d6de0ec9',
+  code: inviteCodeMock,
 };
 
 export const inviteEntityMock: InviteEntity = {


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- Apparently due to DB restrictions, moving the UUID generator to API
- Build in module 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Updating Testing Framework(s)
- [ ] Version change

## How Has This Been Tested?

Swagger

## Development Dependency Working Agreement
- [x] My code DOES NOT include the importing of new dependencies into the DPIA ecosystem
- [ ] My code DOES include the importing of new dependencies into the DPIA ecosystem
**If new dependencies are being introduced to the DPIA ecosystem:**
- [ ] The functionality of the dependency drastically reduces code complexity and makes my changes more easily maintainable and readible 
- [ ] The dependency being introduced does not contain multiple layers of nested dependencies introducing maintainability complexity to the DPIA ecosystem

## Frontend Development Changes
- [x] N/A
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to project documentation or diagrams that reflect my changes
- [ ] New and existing unit tests pass locally with my changes
- [ ] My code follows Airbnb React Style Guidelines

## API Development Changes
- [ ] N/A
- [x] I have performed a self-review of my own code
- [x] My code follows standards and practices outlined in the BC Government API Development Guidelines
- [x] New and existing unit tests pass locally with my changes
- [x] My changes includes Swagger documentation updates that reflect the changes I am introducing

## Definition of Done

![Definition of Done](https://raw.githubusercontent.com/bcgov/cirmo-dpia/main/.github/assets/DoD.jpg)
