### PR TITLE
UTOPIA-1224: Vite Server options (server.fs.deny) can be bypassed using a double forward-slash

### DIFF
--- a/src/frontend/package-lock.json
+++ b/src/frontend/package-lock.json
@@ -52,7 +52,7 @@
         "husky": "8.0.1",
         "jest": "29.1.2",
         "lint-staged": "13.0.3",
-        "multiple-cucumber-html-reporter": "^3.4.0",
+        "multiple-cucumber-html-reporter": "3.4.0",
         "prettier": "2.7.1",
         "stylelint": "14.13.0",
         "stylelint-config-prettier": "9.0.3",
@@ -61,7 +61,7 @@
         "stylelint-prettier": "2.0.0",
         "stylelint-scss": "5.0.0",
         "typescript": "4.6.4",
-        "vite": "3.2.5",
+        "vite": "3.2.7",
         "wdio-chromedriver-service": "8.1.1",
         "wdio-cucumberjs-json-reporter": "5.1.5",
         "wdio-wait-for": "3.0.4"
@@ -18197,9 +18197,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "3.2.5",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-3.2.5.tgz",
-      "integrity": "sha512-4mVEpXpSOgrssFZAOmGIr85wPHKvaDAcXqxVxVRZhljkJOMZi1ibLibzjLHzJvcok8BMguLc7g1W6W/GqZbLdQ==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-3.2.7.tgz",
+      "integrity": "sha512-29pdXjk49xAP0QBr0xXqu2s5jiQIXNvE/xwd0vUizYT2Hzqe4BksNNoWllFVXJf4eLZ+UlVQmXfB4lWrc+t18g==",
       "dev": true,
       "dependencies": {
         "esbuild": "^0.15.9",
@@ -32495,9 +32495,9 @@
       }
     },
     "vite": {
-      "version": "3.2.5",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-3.2.5.tgz",
-      "integrity": "sha512-4mVEpXpSOgrssFZAOmGIr85wPHKvaDAcXqxVxVRZhljkJOMZi1ibLibzjLHzJvcok8BMguLc7g1W6W/GqZbLdQ==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-3.2.7.tgz",
+      "integrity": "sha512-29pdXjk49xAP0QBr0xXqu2s5jiQIXNvE/xwd0vUizYT2Hzqe4BksNNoWllFVXJf4eLZ+UlVQmXfB4lWrc+t18g==",
       "dev": true,
       "requires": {
         "esbuild": "^0.15.9",

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -79,7 +79,7 @@
     "stylelint-prettier": "2.0.0",
     "stylelint-scss": "5.0.0",
     "typescript": "4.6.4",
-    "vite": "3.2.5",
+    "vite": "3.2.7",
     "wdio-chromedriver-service": "8.1.1",
     "wdio-cucumberjs-json-reporter": "5.1.5",
     "wdio-wait-for": "3.0.4"


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- Upgrades vite@3.2.5 => vite@3.2.7

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Updating Testing Framework(s)
- [ ] Version change

## How Has This Been Tested?

Rebuilt and ran the application with no issues.

## Development Dependency Working Agreement
- [x] My code DOES NOT include the importing of new dependencies into the DPIA ecosystem
- [ ] My code DOES include the importing of new dependencies into the DPIA ecosystem
**If new dependencies are being introduced to the DPIA ecosystem:**
- [ ] The functionality of the dependency drastically reduces code complexity and makes my changes more easily maintainable and readable
- [ ] The dependency being introduced does not contain multiple layers of nested dependencies introducing maintainability complexity to the DPIA ecosystem

## Frontend Development Changes
- [ ] N/A
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to project documentation or diagrams that reflect my changes
- [ ] New and existing unit tests pass locally with my changes
- [ ] My code follows Airbnb React Style Guidelines

## API Development Changes
- [x] N/A
- [ ] I have performed a self-review of my own code
- [ ] My code follows standards and practices outlined in the BC Government API Development Guidelines
- [ ] New and existing unit tests pass locally with my changes
- [ ] My changes includes Swagger documentation updates that reflect the changes I am introducing

## Definition of Done

![Definition of Done](https://raw.githubusercontent.com/bcgov/cirmo-dpia/main/.github/assets/DoD.jpg)
