### PR TITLE
UTOPIA-1176 & 1156: (frontend) update modal, statuses, and transitions

### DIFF
--- a/src/frontend/src/components/common/Modal/_modal.scss
+++ b/src/frontend/src/components/common/Modal/_modal.scss
@@ -9,7 +9,6 @@
 
   .modal-title {
     display: block;
-    font-weight: bold;
     text-align: center;
     color: black;
   }
@@ -26,6 +25,8 @@
     text-align: center;
     padding: 0 20px;
     color: black;
+    max-width: 65ch;
+    margin: 0 auto;
   }
 
   .modal-main {
@@ -40,9 +41,9 @@
     transform: translate(-50%, -50%);
     box-shadow: 0 2px 6px 1px rgba(0, 0, 0, 0.15);
     border-radius: 5px;
-  
+
     @include breakpoint(0 map-get($grid-breakpoints, 'md')) {
-      width: 80%; 
+      width: 80%;
     }
   }
 

--- a/src/frontend/src/components/common/Modal/index.tsx
+++ b/src/frontend/src/components/common/Modal/index.tsx
@@ -79,7 +79,7 @@ const Modal = ({
   return (
     <div className={showHideClassName} tabIndex={0} ref={modalRef}>
       <section className="modal-main">
-        <span className="modal-title"> {titleText}</span>
+        <h3 className="modal-title">{titleText}</h3>
         <div className="modal-horizontal-divider"></div>
         {children}
         {accessLink !== '' && accessLink !== undefined && (

--- a/src/frontend/src/sass/_statusBlock.scss
+++ b/src/frontend/src/sass/_statusBlock.scss
@@ -40,16 +40,23 @@
 }
 
 .statusBlock__incomplete {
-  background-color: $bg-white;
+  background-color: $bg-incomplete;
+  color: $fg-incomplete;
 }
 
 .statusBlock__MPOReview {
   background-color: $bg-infoBanner;
+  color: $fg-mpoReview;
 }
 
 .statusBlock__CPOReview {
   background-color: $bg-cpoReview;
   color: $review;
+}
+
+.statusBlock__finalReview {
+  background-color: $bg-finalReview;
+  color: $fg-finalReview;
 }
 
 .statusBlock__completed {
@@ -62,4 +69,5 @@
 
 .statusBlock__edit {
   background-color: $bg-warningBanner;
+  color: $fg-editInProgress;
 }

--- a/src/frontend/src/sass/_variables.scss
+++ b/src/frontend/src/sass/_variables.scss
@@ -1,6 +1,6 @@
 /* Variables
  * The variables here define the default branding of BC GOV. This includes properties like color, font, fontsize, spacing and more.
- * Varabiles naming must follow '$component-state-property-size' convention. 
+ * Varabiles naming must follow '$component-state-property-size' convention.
  * Ex: $nav-link-hover-color or $close-link-color-sm
  */
 
@@ -40,7 +40,19 @@ $bg-successBanner: #dff0d8;
 $bg-infoBanner: #d9eaf7;
 $bg-warningBanner: #f9f1c6;
 $bg-errorBanner: #f2dede;
+
+/* Status Block colours */
 $bg-cpoReview: #ece5ff;
+
+$fg-mpoReview: #1a5a96;
+
+$bg-finalReview: #cfd7ff;
+$fg-finalReview: #0020cb;
+
+$fg-editInProgress: #6c4a00;
+
+$bg-incomplete: #f2f2f2;
+$fg-incomplete: #606060;
 
 /* Semantic colours */
 $error: #d8292f;

--- a/src/frontend/src/utils/status.ts
+++ b/src/frontend/src/utils/status.ts
@@ -74,7 +74,7 @@ const defaultEmptyModal: Modal = {
 
 export const statusList: StatusList = {
   MPO_REVIEW: {
-    title: 'MPO REVIEW',
+    title: 'MPO Review',
     class: 'statusBlock__MPOReview',
     banner: BannerText.MPOReviewStatusCalloutText.Drafter.en,
     modal: defaultMPOReviewModal,
@@ -115,7 +115,7 @@ export const statusList: StatusList = {
     },
   },
   INCOMPLETE: {
-    title: 'INCOMPLETE',
+    title: 'Incomplete',
     class: 'statusBlock__incomplete',
     banner: BannerText.InCompleteStatusCalloutText.Drafter.en,
     modal: defaultIncompleteModal,
@@ -152,7 +152,7 @@ export const statusList: StatusList = {
     },
   },
   COMPLETED: {
-    title: 'COMPLETED',
+    title: 'Completed',
     class: 'statusBlock__success',
     modal: defaultEmptyModal,
     Privileges: {
@@ -175,7 +175,7 @@ export const statusList: StatusList = {
     },
   },
   EDIT_IN_PROGRESS: {
-    title: 'EDIT IN PROGRESS',
+    title: 'Edit in progress',
     class: 'statusBlock__edit',
     modal: {
       title: 'Change status to “Edit in progress”?',
@@ -220,7 +220,7 @@ export const statusList: StatusList = {
     },
   },
   CPO_REVIEW: {
-    title: 'CPO REVIEW',
+    title: 'CPO Review',
     banner: BannerText.CPOReviewStatusCalloutText.Drafter.en,
     class: 'statusBlock__CPOReview',
     modal: defaultCPOReviewModal,
@@ -248,6 +248,91 @@ export const statusList: StatusList = {
           {
             status: 'EDIT_IN_PROGRESS',
             modal: defaultEditInProgressModal,
+          },
+        ],
+      },
+    },
+  },
+  FINAL_REVIEW: {
+    title: 'Final Review',
+    class: 'statusBlock__finalReview',
+    modal: defaultEmptyModal,
+    Privileges: {
+      MPO: {
+        changeStatus: [
+          {
+            status: 'INCOMPLETE',
+            modal: {
+              title: 'Unlock PIA? Reviews will not be saved.',
+              description:
+                'Changing status to Incomplete will erase all data in the "Review" section and all reviewers will have to complete this section again.',
+              confirmLabel: 'Yes, unlock',
+              cancelLabel: 'Cancel',
+            },
+          },
+          {
+            status: 'EDIT_IN_PROGRESS',
+            modal: {
+              title: 'Unlock PIA? Reviews will not be saved.',
+              description:
+                'Changing status to Edit in progress will erase all data in the "Review" section and all reviewers will have to complete this section again.',
+              confirmLabel: 'Yes, unlock',
+              cancelLabel: 'Cancel',
+            },
+          },
+          {
+            status: 'MPO_REVIEW',
+            modal: {
+              title: 'Unlock PIA?',
+              description:
+                'The status will be changed to "MPO Review" and this PIA will be unlocked.',
+              confirmLabel: 'Yes, unlock',
+              cancelLabel: 'Cancel',
+            },
+          },
+        ],
+      },
+      CPO: {
+        changeStatus: [
+          {
+            status: 'CPO_REVIEW',
+            modal: {
+              title: 'Unlock PIA?',
+              description:
+                'The status will be changed to "CPO Review" and this PIA will be unlocked.',
+              confirmLabel: 'Yes, unlock',
+              cancelLabel: 'Cancel',
+            },
+          },
+          {
+            status: 'INCOMPLETE',
+            modal: {
+              title: 'Unlock PIA? Reviews will not be saved.',
+              description:
+                'Changing status to Incomplete will erase all data in the "Review" section and all reviewers will have to complete this section again.',
+              confirmLabel: 'Yes, unlock',
+              cancelLabel: 'Cancel',
+            },
+          },
+          {
+            status: 'EDIT_IN_PROGRESS',
+            modal: {
+              title: 'Unlock PIA? Reviews will not be saved.',
+              description:
+                'Changing status to Edit in progress will erase all data in the "Review" section and all reviewers will have to complete this section again.',
+              confirmLabel: 'Yes, unlock',
+              cancelLabel: 'Cancel',
+            },
+          },
+          {
+            status: 'MPO_REVIEW',
+            modal: {
+              title: 'Unlock PIA?',
+              description:
+                'The status will be changed to "MPO Review" and this PIA will be unlocked.',
+              confirmLabel: 'Yes, unlock',
+              cancelLabel: 'Cancel',
+            },
           },
         ],
       },

--- a/src/frontend/src/utils/status.ts
+++ b/src/frontend/src/utils/status.ts
@@ -65,6 +65,14 @@ const defaultCPOReviewModal: Modal = {
   cancelLabel: 'Cancel',
 };
 
+const defaultFinalReviewModal: Modal = {
+  title: 'Finish review and lock PIA?',
+  description:
+    'The status will be changed to "Final Review" and this PIA will be locked. Program area roles you designated will be required to review the PIA.',
+  confirmLabel: 'Yes, finish',
+  cancelLabel: 'Cancel',
+};
+
 const defaultEmptyModal: Modal = {
   title: '',
   description: '',
@@ -256,7 +264,7 @@ export const statusList: StatusList = {
   FINAL_REVIEW: {
     title: 'Final Review',
     class: 'statusBlock__finalReview',
-    modal: defaultEmptyModal,
+    modal: defaultFinalReviewModal,
     Privileges: {
       MPO: {
         changeStatus: [


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- Modal styling now more accurately matches designs
- Adds 'defaultFinalReviewModal' to the modal property of the Final Review status
- Status colours now more accurate to designs
- Status titles no longer all caps
- Adds Final Review status
- Updates modal content for moving *from* Final Review

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Updating Testing Framework(s)
- [ ] Version change

## How Has This Been Tested?

Used pgAdmin to manually change status of PIAs to Final Review then, using the dropdown, selected different statuses to check modal content. For the Final Review submission modal, I simply added the Final Review to the CPO's privileges in the CPO Review status and selected it in the dropdown. I removed it after the test due to the inability to __actually__ submit to that status at this point in time.

## Development Dependency Working Agreement
- [x] My code DOES NOT include the importing of new dependencies into the DPIA ecosystem
- [ ] My code DOES include the importing of new dependencies into the DPIA ecosystem
**If new dependencies are being introduced to the DPIA ecosystem:**
- [ ] The functionality of the dependency drastically reduces code complexity and makes my changes more easily maintainable and readible 
- [ ] The dependency being introduced does not contain multiple layers of nested dependencies introducing maintainability complexity to the DPIA ecosystem

## Frontend Development Changes
- [ ] N/A
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to project documentation or diagrams that reflect my changes
- [x] New and existing unit tests pass locally with my changes
- [ ] My code follows Airbnb React Style Guidelines

## API Development Changes
- [x] N/A
- [ ] I have performed a self-review of my own code
- [ ] My code follows standards and practices outlined in the BC Government API Development Guidelines
- [ ] New and existing unit tests pass locally with my changes
- [ ] My changes includes Swagger documentation updates that reflect the changes I am introducing

## Definition of Done

![Definition of Done](https://raw.githubusercontent.com/bcgov/cirmo-dpia/main/.github/assets/DoD.jpg)
