### PR TITLE
[UTOPIA-1155] delete review on status revert

### DIFF
--- a/src/backend/src/modules/pia-intake/enums/pia-intake-status.enum.ts
+++ b/src/backend/src/modules/pia-intake/enums/pia-intake-status.enum.ts
@@ -3,4 +3,5 @@ export enum PiaIntakeStatusEnum {
   EDIT_IN_PROGRESS = 'EDIT_IN_PROGRESS',
   MPO_REVIEW = 'MPO_REVIEW',
   CPO_REVIEW = 'CPO_REVIEW',
+  FINAL_REVIEW = 'FINAL_REVIEW',
 }

--- a/src/backend/src/modules/pia-intake/pia-intake.service.ts
+++ b/src/backend/src/modules/pia-intake/pia-intake.service.ts
@@ -61,6 +61,8 @@ export class PiaIntakeService {
 
     this.validateJsonbFields(createPiaIntakeDto, null, accessType);
 
+    this.validateStatusChange(createPiaIntakeDto, null, accessType);
+
     // once validated, updated the review fields
     this.updateReviewSubmissionFields(
       createPiaIntakeDto?.review,
@@ -117,6 +119,9 @@ export class PiaIntakeService {
 
     // validate jsonb fields for role access
     this.validateJsonbFields(updatePiaIntakeDto, existingRecord, accessType);
+
+    // validate status changes and actions
+    this.validateStatusChange(updatePiaIntakeDto, existingRecord, accessType);
 
     // remove the provided saveId
     delete updatePiaIntakeDto.saveId;
@@ -622,6 +627,25 @@ export class PiaIntakeService {
       updatedValue[key].reviewLastUpdatedAt = new Date();
     }
   };
+
+  /**
+   * @method validateStatusChange
+   * TODO: this is a temp method. The status transitions will be dealt properly in the subsequent tasks
+   */
+  validateStatusChange(
+    updatedValue: CreatePiaIntakeDto | UpdatePiaIntakeDto,
+    storedValue: PiaIntakeEntity,
+    userType: UserTypesEnum[],
+  ) {
+    if (
+      userType.includes(UserTypesEnum.CPO) &&
+      storedValue?.status === PiaIntakeStatusEnum.CPO_REVIEW &&
+      (updatedValue?.status === PiaIntakeStatusEnum.INCOMPLETE ||
+        updatedValue?.status === PiaIntakeStatusEnum.EDIT_IN_PROGRESS)
+    ) {
+      updatedValue.review = null;
+    }
+  }
 
   /**
    * @method validateJsonbFields

--- a/src/backend/src/modules/pia-intake/pia-intake.service.ts
+++ b/src/backend/src/modules/pia-intake/pia-intake.service.ts
@@ -638,8 +638,8 @@ export class PiaIntakeService {
     userType: UserTypesEnum[],
   ) {
     if (
-      userType.includes(UserTypesEnum.CPO) &&
-      storedValue?.status === PiaIntakeStatusEnum.CPO_REVIEW &&
+      userType.includes(UserTypesEnum.MPO) &&
+      storedValue?.status === PiaIntakeStatusEnum.FINAL_REVIEW &&
       (updatedValue?.status === PiaIntakeStatusEnum.INCOMPLETE ||
         updatedValue?.status === PiaIntakeStatusEnum.EDIT_IN_PROGRESS)
     ) {

--- a/src/backend/test/unit/pia-intake/pia-intake.service.spec.ts
+++ b/src/backend/test/unit/pia-intake/pia-intake.service.spec.ts
@@ -52,6 +52,7 @@ import {
   inviteEntityMock,
 } from 'test/util/mocks/data/invites.mock';
 import { inviteeEntityMock } from 'test/util/mocks/data/invitee.mock';
+import { UserTypesEnum } from 'src/common/enums/users.enum';
 
 /**
  * @Description
@@ -2349,6 +2350,198 @@ describe('PiaIntakeService', () => {
       await expect(
         service.update(id, updatePiaIntakeDto, user, userRoles),
       ).resolves.not.toThrow();
+    });
+
+    describe(`validateStatusChange method`, () => {
+      it('succeeds to delete review section if CPO changes status from CPO_Review to INCOMPLETE', async () => {
+        const userType: Array<UserTypesEnum> = [UserTypesEnum.CPO];
+
+        const storedValue: PiaIntakeEntity = {
+          ...piaIntakeEntityMock,
+          review: {
+            // random review to be deleted
+            mpo: {
+              isAcknowledged: true,
+              reviewNote: 'ABCD',
+            },
+            programArea: {
+              selectedRoles: ['Manager'],
+            },
+          },
+          saveId: 10,
+          status: PiaIntakeStatusEnum.CPO_REVIEW,
+        };
+
+        const updatedValue: UpdatePiaIntakeDto = {
+          status: PiaIntakeStatusEnum.INCOMPLETE,
+          saveId: 10,
+          review: {
+            mpo: {
+              isAcknowledged: true,
+              reviewNote: 'ABCD2',
+            },
+            programArea: {
+              selectedRoles: ['Manager2'],
+            },
+          },
+        };
+
+        await service.validateStatusChange(updatedValue, storedValue, userType);
+
+        expect(updatedValue.review).toBe(null); // explicitly updating review field to null
+      });
+
+      it('succeeds to delete review section if CPO changes status from CPO_Review to EDIT_IN_PROGRESS', async () => {
+        const userType: Array<UserTypesEnum> = [UserTypesEnum.CPO];
+
+        const storedValue: PiaIntakeEntity = {
+          ...piaIntakeEntityMock,
+          review: {
+            // random review to be deleted
+            mpo: {
+              isAcknowledged: true,
+              reviewNote: 'ABCD',
+            },
+            programArea: {
+              selectedRoles: ['Manager'],
+            },
+          },
+          saveId: 10,
+          status: PiaIntakeStatusEnum.CPO_REVIEW,
+        };
+
+        const updatedValue: UpdatePiaIntakeDto = {
+          status: PiaIntakeStatusEnum.EDIT_IN_PROGRESS,
+          saveId: 10,
+          review: {
+            mpo: {
+              isAcknowledged: true,
+              reviewNote: 'ABCD2',
+            },
+            programArea: {
+              selectedRoles: ['Manager2'],
+            },
+          },
+        };
+
+        await service.validateStatusChange(updatedValue, storedValue, userType);
+
+        expect(updatedValue.review).toBe(null);
+      });
+
+      it('succeeds and DOES NOT delete review section if CPO changes status from CPO_Review to MPO_REVIEW', async () => {
+        const userType: Array<UserTypesEnum> = [UserTypesEnum.CPO];
+
+        const storedValue: PiaIntakeEntity = {
+          ...piaIntakeEntityMock,
+          review: {
+            // random review to be deleted
+            mpo: {
+              isAcknowledged: true,
+              reviewNote: 'ABCD',
+            },
+            programArea: {
+              selectedRoles: ['Manager'],
+            },
+          },
+          saveId: 10,
+          status: PiaIntakeStatusEnum.CPO_REVIEW,
+        };
+
+        const updatedValue: UpdatePiaIntakeDto = {
+          status: PiaIntakeStatusEnum.MPO_REVIEW,
+          saveId: 10,
+          review: {
+            mpo: {
+              isAcknowledged: true,
+              reviewNote: 'ABCD2',
+            },
+            programArea: {
+              selectedRoles: ['Manager2'],
+            },
+          },
+        };
+
+        await service.validateStatusChange(updatedValue, storedValue, userType);
+
+        expect(updatedValue.review).not.toBe(null);
+      });
+
+      it('succeeds and DOES NOT delete review section if user OTHER THAN CPO changes status from CPO_Review to INCOMPLETE', async () => {
+        const userType: Array<UserTypesEnum> = [UserTypesEnum.MPO];
+
+        const storedValue: PiaIntakeEntity = {
+          ...piaIntakeEntityMock,
+          review: {
+            // random review to be deleted
+            mpo: {
+              isAcknowledged: true,
+              reviewNote: 'ABCD',
+            },
+            programArea: {
+              selectedRoles: ['Manager'],
+            },
+          },
+          saveId: 10,
+          status: PiaIntakeStatusEnum.CPO_REVIEW,
+        };
+
+        const updatedValue: UpdatePiaIntakeDto = {
+          status: PiaIntakeStatusEnum.INCOMPLETE,
+          saveId: 10,
+          review: {
+            mpo: {
+              isAcknowledged: true,
+              reviewNote: 'ABCD2',
+            },
+            programArea: {
+              selectedRoles: ['Manager2'],
+            },
+          },
+        };
+
+        await service.validateStatusChange(updatedValue, storedValue, userType);
+
+        expect(updatedValue.review).not.toBe(null);
+      });
+
+      it('succeeds and DOES NOT delete review section if user OTHER THAN CPO changes status from CPO_Review to EDIT_IN_PROGRESS', async () => {
+        const userType: Array<UserTypesEnum> = [];
+
+        const storedValue: PiaIntakeEntity = {
+          ...piaIntakeEntityMock,
+          review: {
+            // random review to be deleted
+            mpo: {
+              isAcknowledged: true,
+              reviewNote: 'ABCD',
+            },
+            programArea: {
+              selectedRoles: ['Manager'],
+            },
+          },
+          saveId: 10,
+          status: PiaIntakeStatusEnum.CPO_REVIEW,
+        };
+
+        const updatedValue: UpdatePiaIntakeDto = {
+          status: PiaIntakeStatusEnum.EDIT_IN_PROGRESS,
+          saveId: 10,
+          review: {
+            mpo: {
+              isAcknowledged: true,
+              reviewNote: 'ABCD2',
+            },
+            programArea: {
+              selectedRoles: ['Manager2'],
+            },
+          },
+        };
+
+        await service.validateStatusChange(updatedValue, storedValue, userType);
+
+        expect(updatedValue.review).not.toBe(null);
+      });
     });
   });
 

--- a/src/backend/test/unit/pia-intake/pia-intake.service.spec.ts
+++ b/src/backend/test/unit/pia-intake/pia-intake.service.spec.ts
@@ -2353,8 +2353,8 @@ describe('PiaIntakeService', () => {
     });
 
     describe(`validateStatusChange method`, () => {
-      it('succeeds to delete review section if CPO changes status from CPO_Review to INCOMPLETE', async () => {
-        const userType: Array<UserTypesEnum> = [UserTypesEnum.CPO];
+      it('succeeds to delete review section if MPO changes status from FINAL_REVIEW to INCOMPLETE', async () => {
+        const userType: Array<UserTypesEnum> = [UserTypesEnum.MPO];
 
         const storedValue: PiaIntakeEntity = {
           ...piaIntakeEntityMock,
@@ -2369,7 +2369,7 @@ describe('PiaIntakeService', () => {
             },
           },
           saveId: 10,
-          status: PiaIntakeStatusEnum.CPO_REVIEW,
+          status: PiaIntakeStatusEnum.FINAL_REVIEW,
         };
 
         const updatedValue: UpdatePiaIntakeDto = {
@@ -2391,8 +2391,8 @@ describe('PiaIntakeService', () => {
         expect(updatedValue.review).toBe(null); // explicitly updating review field to null
       });
 
-      it('succeeds to delete review section if CPO changes status from CPO_Review to EDIT_IN_PROGRESS', async () => {
-        const userType: Array<UserTypesEnum> = [UserTypesEnum.CPO];
+      it('succeeds to delete review section if MPO changes status from FINAL_REVIEW to EDIT_IN_PROGRESS', async () => {
+        const userType: Array<UserTypesEnum> = [UserTypesEnum.MPO];
 
         const storedValue: PiaIntakeEntity = {
           ...piaIntakeEntityMock,
@@ -2407,7 +2407,7 @@ describe('PiaIntakeService', () => {
             },
           },
           saveId: 10,
-          status: PiaIntakeStatusEnum.CPO_REVIEW,
+          status: PiaIntakeStatusEnum.FINAL_REVIEW,
         };
 
         const updatedValue: UpdatePiaIntakeDto = {
@@ -2429,8 +2429,8 @@ describe('PiaIntakeService', () => {
         expect(updatedValue.review).toBe(null);
       });
 
-      it('succeeds and DOES NOT delete review section if CPO changes status from CPO_Review to MPO_REVIEW', async () => {
-        const userType: Array<UserTypesEnum> = [UserTypesEnum.CPO];
+      it('succeeds and DOES NOT delete review section if MPO changes status from FINAL_REVIEW to MPO_REVIEW', async () => {
+        const userType: Array<UserTypesEnum> = [UserTypesEnum.MPO];
 
         const storedValue: PiaIntakeEntity = {
           ...piaIntakeEntityMock,
@@ -2445,7 +2445,7 @@ describe('PiaIntakeService', () => {
             },
           },
           saveId: 10,
-          status: PiaIntakeStatusEnum.CPO_REVIEW,
+          status: PiaIntakeStatusEnum.FINAL_REVIEW,
         };
 
         const updatedValue: UpdatePiaIntakeDto = {
@@ -2467,8 +2467,8 @@ describe('PiaIntakeService', () => {
         expect(updatedValue.review).not.toBe(null);
       });
 
-      it('succeeds and DOES NOT delete review section if user OTHER THAN CPO changes status from CPO_Review to INCOMPLETE', async () => {
-        const userType: Array<UserTypesEnum> = [UserTypesEnum.MPO];
+      it('succeeds and DOES NOT delete review section if user OTHER THAN MPO changes status from FINAL_REVIEW to INCOMPLETE', async () => {
+        const userType: Array<UserTypesEnum> = [UserTypesEnum.CPO];
 
         const storedValue: PiaIntakeEntity = {
           ...piaIntakeEntityMock,
@@ -2483,7 +2483,7 @@ describe('PiaIntakeService', () => {
             },
           },
           saveId: 10,
-          status: PiaIntakeStatusEnum.CPO_REVIEW,
+          status: PiaIntakeStatusEnum.FINAL_REVIEW,
         };
 
         const updatedValue: UpdatePiaIntakeDto = {
@@ -2505,8 +2505,8 @@ describe('PiaIntakeService', () => {
         expect(updatedValue.review).not.toBe(null);
       });
 
-      it('succeeds and DOES NOT delete review section if user OTHER THAN CPO changes status from CPO_Review to EDIT_IN_PROGRESS', async () => {
-        const userType: Array<UserTypesEnum> = [];
+      it('succeeds and DOES NOT delete review section if user OTHER THAN MPO changes status from FINAL_REVIEW to EDIT_IN_PROGRESS', async () => {
+        const userType: Array<UserTypesEnum> = [UserTypesEnum.DRAFTER];
 
         const storedValue: PiaIntakeEntity = {
           ...piaIntakeEntityMock,
@@ -2521,7 +2521,7 @@ describe('PiaIntakeService', () => {
             },
           },
           saveId: 10,
-          status: PiaIntakeStatusEnum.CPO_REVIEW,
+          status: PiaIntakeStatusEnum.FINAL_REVIEW,
         };
 
         const updatedValue: UpdatePiaIntakeDto = {


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- Delete review section when moving from FINAL_REVIEW to Incomplete/Edit in Progress

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Updating Testing Framework(s)
- [ ] Version change

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Development Dependency Working Agreement
- [x] My code DOES NOT include the importing of new dependencies into the DPIA ecosystem
- [ ] My code DOES include the importing of new dependencies into the DPIA ecosystem
**If new dependencies are being introduced to the DPIA ecosystem:**
- [ ] The functionality of the dependency drastically reduces code complexity and makes my changes more easily maintainable and readible 
- [ ] The dependency being introduced does not contain multiple layers of nested dependencies introducing maintainability complexity to the DPIA ecosystem

## Frontend Development Changes
- [ ] N/A
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to project documentation or diagrams that reflect my changes
- [ ] New and existing unit tests pass locally with my changes
- [ ] My code follows Airbnb React Style Guidelines

## API Development Changes
- [ ] N/A
- [x] I have performed a self-review of my own code
- [x] My code follows standards and practices outlined in the BC Government API Development Guidelines
- [x] New and existing unit tests pass locally with my changes
- [ ] My changes includes Swagger documentation updates that reflect the changes I am introducing

## Definition of Done

![Definition of Done](https://raw.githubusercontent.com/bcgov/cirmo-dpia/main/.github/assets/DoD.jpg)
