### PR TITLE
[UTOPIA-1238] hide review tab after change status from final_review to incomplete/edit_in_progress

### DIFF
--- a/src/frontend/src/components/public/PIASideNav/pia-form-sideNav-pages.ts
+++ b/src/frontend/src/components/public/PIASideNav/pia-form-sideNav-pages.ts
@@ -11,6 +11,7 @@ import { buildDynamicPath } from '../../../utils/path';
 import { INavbarItem } from '../../common/Navbar/interfaces';
 import { useLocation } from 'react-router-dom';
 import { useMemo } from 'react';
+import { PiaStatuses } from '../../../constant/constant';
 
 export const PiaFormSideNavPages = (
   pia: IPiaForm,
@@ -48,7 +49,9 @@ export const PiaFormSideNavPages = (
   const enableReview = (): boolean => {
     if (
       pia?.hasAddedPiToDataElements === false &&
-      pia?.isNextStepsSeenForDelegatedFlow === true
+      pia?.isNextStepsSeenForDelegatedFlow === true &&
+      pia?.status !== PiaStatuses.INCOMPLETE &&
+      pia?.status !== PiaStatuses.EDIT_IN_PROGRESS
     ) {
       // This is for delegated review
       if (isMPORole()) {

--- a/src/frontend/src/pages/PIAForm/index.tsx
+++ b/src/frontend/src/pages/PIAForm/index.tsx
@@ -486,8 +486,17 @@ const PIAFormPage = () => {
       // if a CPO move a PIA from CPO_Review to MPO_Review
       // it can not access the PIA anymore, current it throw a 403 error
       // this fix by move the page to pia list table instead of stay in pia view page.
-
       if (isCPORole()) navigate(routes.PIA_LIST, { replace: true });
+
+      // For a delegate PIA, change from final review to incomplete/dit_in_progress status
+      // will hide review tab so we need to redirect path to intake
+      if (
+        pathname?.split('/').includes('review') &&
+        (status === PiaStatuses.EDIT_IN_PROGRESS ||
+          status === PiaStatuses.INCOMPLETE)
+      ) {
+        navigate(pathname.replace('review', 'intake'), { replace: true });
+      }
     } catch (err: any) {
       setMessage(err.message || 'Something went wrong. Please try again.');
     }


### PR DESCRIPTION


# Description

This PR includes the following proposed change(s):

- hide review tab if change status from final review to incomplete/edit in progres
- if user change status in review tab, redirect to intake tab as the review tab will disappear after status change

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Updating Testing Framework(s)
- [ ] Version change

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Development Dependency Working Agreement
- [x] My code DOES NOT include the importing of new dependencies into the DPIA ecosystem
- [ ] My code DOES include the importing of new dependencies into the DPIA ecosystem
**If new dependencies are being introduced to the DPIA ecosystem:**
- [ ] The functionality of the dependency drastically reduces code complexity and makes my changes more easily maintainable and readible 
- [ ] The dependency being introduced does not contain multiple layers of nested dependencies introducing maintainability complexity to the DPIA ecosystem

## Frontend Development Changes
- [ ] N/A
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to project documentation or diagrams that reflect my changes
- [ ] New and existing unit tests pass locally with my changes
- [ ] My code follows Airbnb React Style Guidelines

## API Development Changes
- [x] N/A
- [ ] I have performed a self-review of my own code
- [ ] My code follows standards and practices outlined in the BC Government API Development Guidelines
- [ ] New and existing unit tests pass locally with my changes
- [ ] My changes includes Swagger documentation updates that reflect the changes I am introducing

## Definition of Done

![Definition of Done](https://raw.githubusercontent.com/bcgov/cirmo-dpia/main/.github/assets/DoD.jpg)
