### PR TITLE
[Utopia 1253] update btn text

### DIFF
--- a/src/frontend/src/components/public/PIASubHeader/index.tsx
+++ b/src/frontend/src/components/public/PIASubHeader/index.tsx
@@ -130,7 +130,7 @@ function PIASubHeader({
     }
     if (
       enableFinalReview === false &&
-      primaryButtonText === SubmitButtonTextEnum.DELEGATE_FINAL_REVIEW
+      primaryButtonText === SubmitButtonTextEnum.DELEGATE_FINISH_REVIEW
     ) {
       setDisableSubmitButton(true);
     } else {

--- a/src/frontend/src/pages/PIAForm/index.tsx
+++ b/src/frontend/src/pages/PIAForm/index.tsx
@@ -236,7 +236,7 @@ const PIAFormPage = () => {
       pia.status === PiaStatuses.MPO_REVIEW &&
       pia.hasAddedPiToDataElements === false
     ) {
-      setSubmitButtonText(SubmitButtonTextEnum.DELEGATE_FINAL_REVIEW);
+      setSubmitButtonText(SubmitButtonTextEnum.DELEGATE_FINISH_REVIEW);
     } else if (onIntakePage || onNewPiaPage) {
       setSubmitButtonText(SubmitButtonTextEnum.INTAKE);
     } else {

--- a/src/frontend/src/pages/PIAForm/index.tsx
+++ b/src/frontend/src/pages/PIAForm/index.tsx
@@ -49,7 +49,7 @@ export interface PiaValidationMessage {
 export enum SubmitButtonTextEnum {
   INTAKE = 'Submit',
   FORM = 'Submit',
-  DELEGATE_FINAL_REVIEW = 'Final review',
+  DELEGATE_FINISH_REVIEW = 'Finish review',
 }
 
 export enum PiaFormSubmissionTypeEnum {


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- update button text to finish review from final review
<img width="1899" alt="Screenshot 2023-06-30 at 1 07 53 PM" src="https://github.com/bcgov/cirmo-dpia/assets/57013495/e6df373c-a641-4ccc-af53-6afd94f47fc7">

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Updating Testing Framework(s)
- [ ] Version change

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Development Dependency Working Agreement
- [x] My code DOES NOT include the importing of new dependencies into the DPIA ecosystem
- [ ] My code DOES include the importing of new dependencies into the DPIA ecosystem
**If new dependencies are being introduced to the DPIA ecosystem:**
- [ ] The functionality of the dependency drastically reduces code complexity and makes my changes more easily maintainable and readible 
- [ ] The dependency being introduced does not contain multiple layers of nested dependencies introducing maintainability complexity to the DPIA ecosystem

## Frontend Development Changes
- [ ] N/A
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to project documentation or diagrams that reflect my changes
- [ ] New and existing unit tests pass locally with my changes
- [ ] My code follows Airbnb React Style Guidelines

## API Development Changes
- [x] N/A
- [ ] I have performed a self-review of my own code
- [ ] My code follows standards and practices outlined in the BC Government API Development Guidelines
- [ ] New and existing unit tests pass locally with my changes
- [ ] My changes includes Swagger documentation updates that reflect the changes I am introducing

## Definition of Done

![Definition of Done](https://raw.githubusercontent.com/bcgov/cirmo-dpia/main/.github/assets/DoD.jpg)
