### PR TITLE
UTOPIA-1154: Disallow URL navigation to Edit mode when in Signature mode

### DIFF
--- a/src/frontend/src/pages/PIAForm/index.tsx
+++ b/src/frontend/src/pages/PIAForm/index.tsx
@@ -303,9 +303,9 @@ const PIAFormPage = () => {
         setPiaModalButtonValue('save');
         break;
       case 'edit':
-        /* Using the state table, we can determine which modal to show based on the status of the PIA 
+        /* Using the state table, we can determine which modal to show based on the status of the PIA
            This will keep the modal text in one place and allow for easy updates in the future
-           and will make the whole app consistent. 
+           and will make the whole app consistent.
         */
         PopulateModal(pia, PiaStatuses.EDIT_IN_PROGRESS, populateModalFn);
         setPiaModalButtonValue('edit');
@@ -833,20 +833,6 @@ const PIAFormPage = () => {
     return () => clearTimeout(autoSaveTimer);
   });
 
-  /**
-   * On load, check if the pia status is CPO_REVIEW
-   * If it is, make sure the form is readonly
-   */
-  useEffect(() => {
-    try {
-      if (pia?.status === PiaStatuses.CPO_REVIEW) {
-        setFormReadOnly(true);
-      }
-    } catch (err) {
-      console.error(err);
-    }
-  }, [pia.status]);
-
   useEffect(() => {
     window.addEventListener('beforeunload', alertUserLeave);
     return () => {
@@ -864,6 +850,7 @@ const PIAFormPage = () => {
     ) {
       // change edit to view
       pathname?.replace('edit', 'view');
+      setFormReadOnly(true);
     }
   }, [pia?.status, id, pathname]);
 


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- Add setFormReadOnly(true) for all non-editable statuses

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Updating Testing Framework(s)
- [ ] Version change

## How Has This Been Tested?

Attempted URL manipulation within all non-edit statuses

## Development Dependency Working Agreement
- [x] My code DOES NOT include the importing of new dependencies into the DPIA ecosystem
- [ ] My code DOES include the importing of new dependencies into the DPIA ecosystem
**If new dependencies are being introduced to the DPIA ecosystem:**
- [ ] The functionality of the dependency drastically reduces code complexity and makes my changes more easily maintainable and readible 
- [ ] The dependency being introduced does not contain multiple layers of nested dependencies introducing maintainability complexity to the DPIA ecosystem

## Frontend Development Changes
- [ ] N/A
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to project documentation or diagrams that reflect my changes
- [x] New and existing unit tests pass locally with my changes
- [ ] My code follows Airbnb React Style Guidelines

## API Development Changes
- [x] N/A
- [ ] I have performed a self-review of my own code
- [ ] My code follows standards and practices outlined in the BC Government API Development Guidelines
- [ ] New and existing unit tests pass locally with my changes
- [ ] My changes includes Swagger documentation updates that reflect the changes I am introducing

## Definition of Done

![Definition of Done](https://raw.githubusercontent.com/bcgov/cirmo-dpia/main/.github/assets/DoD.jpg)
