### PR TITLE
UTOPIA-1281: Drafters can access Review Page in MPO review status

### DIFF
--- a/src/frontend/src/components/public/PIANavButton/index.tsx
+++ b/src/frontend/src/components/public/PIANavButton/index.tsx
@@ -1,8 +1,9 @@
 import { useLocation, useNavigate } from 'react-router-dom';
 import { INavButton } from './interface';
 import HandleState from './handleState';
+import { roleCheck } from '../../../utils/helper.util';
 
-const PIANavButton = ({ pages }: INavButton) => {
+const PIANavButton = ({ pages, isDelegate }: INavButton) => {
   const { pathname } = useLocation();
   const navigate = useNavigate();
 
@@ -30,6 +31,8 @@ const PIANavButton = ({ pages }: INavButton) => {
     }
   };
 
+  const userRole = roleCheck().roles;
+
   return (
     <>
       {(HandleState(pages, pathname, 'prev') ||
@@ -49,18 +52,19 @@ const PIANavButton = ({ pages }: INavButton) => {
               : 'Back'}
           </button>
         )}
-        {HandleState(pages, pathname, 'next') && (
-          <button
-            className="bcgovbtn bcgovbtn__secondary btn-next ms-auto"
-            onClick={handleNext}
-            type="button"
-            aria-label="Next Button"
-          >
-            {typeof HandleState(pages, pathname, 'next') === 'object'
-              ? Object(HandleState(pages, pathname, 'next'))?.title
-              : 'Next'}
-          </button>
-        )}
+        {HandleState(pages, pathname, 'next') &&
+          (!isDelegate || userRole !== undefined) && (
+            <button
+              className="bcgovbtn bcgovbtn__secondary btn-next ms-auto"
+              onClick={handleNext}
+              type="button"
+              aria-label="Next Button"
+            >
+              {typeof HandleState(pages, pathname, 'next') === 'object'
+                ? Object(HandleState(pages, pathname, 'next'))?.title
+                : 'Next'}
+            </button>
+          )}
       </div>
     </>
   );


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- Drafters without a role will no longer see a next button on the next steps tab

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Updating Testing Framework(s)
- [ ] Version change

## How Has This Been Tested?

Changed roles and visually asserted the presence (or lack of) 'Next' button on Next Steps tab

## Development Dependency Working Agreement
- [x] My code DOES NOT include the importing of new dependencies into the DPIA ecosystem
- [ ] My code DOES include the importing of new dependencies into the DPIA ecosystem
**If new dependencies are being introduced to the DPIA ecosystem:**
- [ ] The functionality of the dependency drastically reduces code complexity and makes my changes more easily maintainable and readible 
- [ ] The dependency being introduced does not contain multiple layers of nested dependencies introducing maintainability complexity to the DPIA ecosystem

## Frontend Development Changes
- [ ] N/A
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to project documentation or diagrams that reflect my changes
- [ ] New and existing unit tests pass locally with my changes
- [ ] My code follows Airbnb React Style Guidelines

## API Development Changes
- [x] N/A
- [ ] I have performed a self-review of my own code
- [ ] My code follows standards and practices outlined in the BC Government API Development Guidelines
- [ ] New and existing unit tests pass locally with my changes
- [ ] My changes includes Swagger documentation updates that reflect the changes I am introducing

## Definition of Done

![Definition of Done](https://raw.githubusercontent.com/bcgov/cirmo-dpia/main/.github/assets/DoD.jpg)
