### PR TITLE
UTOPIA-1330: Program area reviews not showing in Complete status

### DIFF
--- a/src/frontend/src/components/public/PIAFormTabs/review/index.tsx
+++ b/src/frontend/src/components/public/PIAFormTabs/review/index.tsx
@@ -18,6 +18,7 @@ import PendingReview from './pendingReview';
 import ViewProgramAreaReview from './viewProgramArea';
 import EditProgramAreaReview from './editProgramArea';
 import { YesNoInput } from '../../../../types/enums/yes-no.enum';
+import { statusList } from '../../../../utils/status';
 
 export interface IReviewProps {
   printPreview?: boolean;
@@ -196,6 +197,7 @@ const PIAReview = ({ printPreview }: IReviewProps) => {
     const review = { isAcknowledged: mpoAcknowledged, reviewNote };
     stateChangeHandler(review, `mpo`, true);
   };
+
   return (
     <>
       <section>
@@ -300,8 +302,9 @@ const PIAReview = ({ printPreview }: IReviewProps) => {
                     reviewForm.programArea?.selectedRoles.map(
                       (role: string, index: number) => {
                         return reviewForm.programArea?.selectedRoles &&
-                          (pia.status === PiaStatuses.FINAL_REVIEW ||
-                            pia.status === PiaStatuses.COMPLETE) ? (
+                          // eslint-disable-next-line @typescript-eslint/no-non-null-asserted-optional-chain
+                          statusList?.(pia)?.[pia?.status!]?.Pages?.review
+                            .viewProgramAreaReviews ? (
                           <div
                             className="d-flex align-items-center"
                             key={index}

--- a/src/frontend/src/components/public/PIAFormTabs/review/index.tsx
+++ b/src/frontend/src/components/public/PIAFormTabs/review/index.tsx
@@ -7,9 +7,7 @@ import { useCallback, useContext, useEffect, useMemo, useState } from 'react';
 import { IReview } from './interfaces';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faTrash } from '@fortawesome/free-solid-svg-icons';
-import { useParams } from 'react-router-dom';
 import { getGUID } from '../../../../utils/helper.util';
-import { IPiaForm } from '../../../../types/interfaces/pia-form.interface';
 import {
   IPiaFormContext,
   PiaFormContext,
@@ -302,7 +300,8 @@ const PIAReview = ({ printPreview }: IReviewProps) => {
                     reviewForm.programArea?.selectedRoles.map(
                       (role: string, index: number) => {
                         return reviewForm.programArea?.selectedRoles &&
-                          pia.status === PiaStatuses.FINAL_REVIEW ? (
+                          (pia.status === PiaStatuses.FINAL_REVIEW ||
+                            pia.status === PiaStatuses.COMPLETE) ? (
                           <div
                             className="d-flex align-items-center"
                             key={index}

--- a/src/frontend/src/components/public/PIAFormTabs/review/viewReviewSection.tsx
+++ b/src/frontend/src/components/public/PIAFormTabs/review/viewReviewSection.tsx
@@ -51,20 +51,22 @@ const ViewReviewSection = (props: IReviewProps) => {
         <div className="mt-2">{reviewSection?.reviewedByDisplayName}</div>
       </div>
 
-      {reviewGuid === getGUID() && !printPreview && pia.status !== PiaStatuses.COMPLETE && (
-        <div className=" col d-flex justify-content-end">
-          <button
-            className="bcgovbtn bcgovbtn__tertiary p-3"
-            onClick={() => {
-              if (editReviewNote) editReviewNote(true);
-              else if (stateChangeHandler) setEditReview(true);
-            }}
-          >
-            <FontAwesomeIcon className="ms-1" icon={faFileEdit} size="lg" />
-            Edit review
-          </button>
-        </div>
-      )}
+      {reviewGuid === getGUID() &&
+        !printPreview &&
+        pia.status !== PiaStatuses.COMPLETE && (
+          <div className=" col d-flex justify-content-end">
+            <button
+              className="bcgovbtn bcgovbtn__tertiary p-3"
+              onClick={() => {
+                if (editReviewNote) editReviewNote(true);
+                else if (stateChangeHandler) setEditReview(true);
+              }}
+            >
+              <FontAwesomeIcon className="ms-1" icon={faFileEdit} size="lg" />
+              Edit review
+            </button>
+          </div>
+        )}
 
       <div className="row mt-4 ">
         <div className="col col-md-3">

--- a/src/frontend/src/components/public/PIAFormTabs/review/viewReviewSection.tsx
+++ b/src/frontend/src/components/public/PIAFormTabs/review/viewReviewSection.tsx
@@ -9,6 +9,7 @@ import { IPiaForm } from '../../../../types/interfaces/pia-form.interface';
 import { dateToString } from '../../../../utils/date';
 import { getGUID } from '../../../../utils/helper.util';
 import { IReviewSection, IReview } from './interfaces';
+import { statusList } from '../../../../utils/status';
 
 interface IReviewProps {
   pia: IPiaForm;
@@ -33,6 +34,11 @@ const ViewReviewSection = (props: IReviewProps) => {
 
   const reviewGuid = reviewSection?.reviewedByGuid;
 
+  const canEditReviewNote =
+    reviewGuid === getGUID() &&
+    !printPreview &&
+    statusList?.(pia)?.[pia?.status!]?.Pages?.review?.params?.editReviewNote;
+
   const [editReview, setEditReview] = useState(false);
   const [reviewNote, setReviewNote] = useState(
     pia.review?.programArea?.reviews?.[
@@ -51,22 +57,20 @@ const ViewReviewSection = (props: IReviewProps) => {
         <div className="mt-2">{reviewSection?.reviewedByDisplayName}</div>
       </div>
 
-      {reviewGuid === getGUID() &&
-        !printPreview &&
-        pia.status !== PiaStatuses.COMPLETE && (
-          <div className=" col d-flex justify-content-end">
-            <button
-              className="bcgovbtn bcgovbtn__tertiary p-3"
-              onClick={() => {
-                if (editReviewNote) editReviewNote(true);
-                else if (stateChangeHandler) setEditReview(true);
-              }}
-            >
-              <FontAwesomeIcon className="ms-1" icon={faFileEdit} size="lg" />
-              Edit review
-            </button>
-          </div>
-        )}
+      {canEditReviewNote && (
+        <div className=" col d-flex justify-content-end">
+          <button
+            className="bcgovbtn bcgovbtn__tertiary p-3"
+            onClick={() => {
+              if (editReviewNote) editReviewNote(true);
+              else if (stateChangeHandler) setEditReview(true);
+            }}
+          >
+            <FontAwesomeIcon className="ms-1" icon={faFileEdit} size="lg" />
+            Edit review
+          </button>
+        </div>
+      )}
 
       <div className="row mt-4 ">
         <div className="col col-md-3">

--- a/src/frontend/src/components/public/PIAFormTabs/review/viewReviewSection.tsx
+++ b/src/frontend/src/components/public/PIAFormTabs/review/viewReviewSection.tsx
@@ -1,7 +1,7 @@
 import Checkbox from '../../../common/Checkbox';
 import messages from './messages';
 import { PiaStatuses } from '../../../../constant/constant';
-import { Dispatch, SetStateAction, useState, useEffect } from 'react';
+import { Dispatch, SetStateAction, useState } from 'react';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faFileEdit } from '@fortawesome/free-solid-svg-icons';
 
@@ -51,7 +51,7 @@ const ViewReviewSection = (props: IReviewProps) => {
         <div className="mt-2">{reviewSection?.reviewedByDisplayName}</div>
       </div>
 
-      {reviewGuid === getGUID() && !printPreview && (
+      {reviewGuid === getGUID() && !printPreview && pia.status !== PiaStatuses.COMPLETE && (
         <div className=" col d-flex justify-content-end">
           <button
             className="bcgovbtn bcgovbtn__tertiary p-3"

--- a/src/frontend/src/components/public/PIAFormTabs/review/viewReviewSection.tsx
+++ b/src/frontend/src/components/public/PIAFormTabs/review/viewReviewSection.tsx
@@ -1,6 +1,5 @@
 import Checkbox from '../../../common/Checkbox';
 import messages from './messages';
-import { PiaStatuses } from '../../../../constant/constant';
 import { Dispatch, SetStateAction, useState } from 'react';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faFileEdit } from '@fortawesome/free-solid-svg-icons';
@@ -37,6 +36,7 @@ const ViewReviewSection = (props: IReviewProps) => {
   const canEditReviewNote =
     reviewGuid === getGUID() &&
     !printPreview &&
+    // eslint-disable-next-line @typescript-eslint/no-non-null-asserted-optional-chain
     statusList?.(pia)?.[pia?.status!]?.Pages?.review?.params?.editReviewNote;
 
   const [editReview, setEditReview] = useState(false);

--- a/src/frontend/src/utils/status.ts
+++ b/src/frontend/src/utils/status.ts
@@ -6,6 +6,7 @@ import { SubmitButtonTextEnum } from '../pages/PIAForm';
 export type PageAccessControl = {
   [page: string]: {
     accessControl: boolean;
+    viewProgramAreaReviews?: boolean;
   };
 };
 
@@ -293,6 +294,7 @@ export const statusList = (pia: IPiaForm | null): StatusList => {
       Pages: {
         review: {
           accessControl: true,
+          viewProgramAreaReviews: true,
         },
       },
       Privileges: {
@@ -414,6 +416,7 @@ export const statusList = (pia: IPiaForm | null): StatusList => {
       Pages: {
         review: {
           accessControl: true,
+          viewProgramAreaReviews: true,
         },
       },
       Privileges: {

--- a/src/frontend/src/utils/status.ts
+++ b/src/frontend/src/utils/status.ts
@@ -6,6 +6,7 @@ import { SubmitButtonTextEnum } from '../pages/PIAForm';
 export type PageAccessControl = {
   [page: string]: {
     accessControl: boolean;
+    params?: any;
     viewProgramAreaReviews?: boolean;
   };
 };
@@ -175,6 +176,9 @@ export const statusList = (pia: IPiaForm | null): StatusList => {
       Pages: {
         review: {
           accessControl: false,
+          params: {
+            editReviewNote: true,
+          },
         },
       },
       Privileges: {
@@ -365,6 +369,9 @@ export const statusList = (pia: IPiaForm | null): StatusList => {
       Pages: {
         review: {
           accessControl: false,
+          params: {
+            editReviewNote: true,
+          },
         },
       },
       Privileges: {
@@ -417,6 +424,9 @@ export const statusList = (pia: IPiaForm | null): StatusList => {
         review: {
           accessControl: true,
           viewProgramAreaReviews: true,
+          params: {
+            editReviewNote: true,
+          },
         },
       },
       Privileges: {


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- Checks for COMPLETE status as well now for rendering full Program Area reviews
- Removes Program Area 'Edit review' button when in COMPLETE status

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Updating Testing Framework(s)
- [ ] Version change

## How Has This Been Tested?

Visually checked the UI for Program Area reviews when a PIA is in COMPLETE status

## Development Dependency Working Agreement
- [x] My code DOES NOT include the importing of new dependencies into the DPIA ecosystem
- [ ] My code DOES include the importing of new dependencies into the DPIA ecosystem
**If new dependencies are being introduced to the DPIA ecosystem:**
- [ ] The functionality of the dependency drastically reduces code complexity and makes my changes more easily maintainable and readible 
- [ ] The dependency being introduced does not contain multiple layers of nested dependencies introducing maintainability complexity to the DPIA ecosystem

## Frontend Development Changes
- [ ] N/A
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to project documentation or diagrams that reflect my changes
- [ ] New and existing unit tests pass locally with my changes
- [ ] My code follows Airbnb React Style Guidelines

## API Development Changes
- [x] N/A
- [ ] I have performed a self-review of my own code
- [ ] My code follows standards and practices outlined in the BC Government API Development Guidelines
- [ ] New and existing unit tests pass locally with my changes
- [ ] My changes includes Swagger documentation updates that reflect the changes I am introducing

## Definition of Done

![Definition of Done](https://raw.githubusercontent.com/bcgov/cirmo-dpia/main/.github/assets/DoD.jpg)
