### PR TITLE
[UTOPIA-1395] Selected program area roles not visible when partially signed in Final Review

### DIFF
--- a/src/frontend/src/components/public/PIAFormTabs/review/ProgamArea/displayProgramArea.tsx
+++ b/src/frontend/src/components/public/PIAFormTabs/review/ProgamArea/displayProgramArea.tsx
@@ -38,10 +38,12 @@ const DisplayProgramArea = (props: IDisplayProgramAreaProps) => {
     reviewPagePrivilegeParams?.editProgramAreaReview ?? false;
 
   // Logic Explanation:
-  //   - When this function returns true, it means the readonly.
-  //   - When this function returns false, it means allow editing the review.
-  const viewUserReviewProgramArea = () => {
-    if (canEditProgramAreaReview) return false;
+  // - When this function returns true, it allows a drafter and reviewer to view their own review in view mode.
+  // - When this function returns false, it allows a drafter and reviewer to edit their own review.
+  const viewMode = (reviewerRole: string) => {
+    const reviewerRoleAcknowledged = Object(props.pia?.review?.programArea)
+      ?.reviews?.[reviewerRole]?.isAcknowledged;
+    if (canEditProgramAreaReview || !reviewerRoleAcknowledged) return false;
 
     // if selectedRoles is null means none of selectedRole got reviewed so return true
     // otherwise loop all the role in reviews part to see if the current user already did review
@@ -113,7 +115,7 @@ const DisplayProgramArea = (props: IDisplayProgramAreaProps) => {
             </div>
           ) : (
             <div className="d-flex align-items-center" key={index}>
-              {viewUserReviewProgramArea() ||
+              {viewMode(role) ||
               Object(props.pia?.review?.programArea)?.reviews?.[role]
                 ?.isAcknowledged ? (
                 <ViewProgramAreaReview

--- a/src/frontend/src/components/public/PIAFormTabs/review/ProgamArea/displayProgramArea.tsx
+++ b/src/frontend/src/components/public/PIAFormTabs/review/ProgamArea/displayProgramArea.tsx
@@ -38,7 +38,7 @@ const DisplayProgramArea = (props: IDisplayProgramAreaProps) => {
     reviewPagePrivilegeParams?.editProgramAreaReview ?? false;
 
   const allowUserReviewProgramArea = () => {
-    if (!canEditProgramAreaReview) return false;
+    if (canEditProgramAreaReview) return false;
 
     // if selectedRoles is null means none of selectedRole got reviewed so return true
     // otherwise loop all the role in reviews part to see if the current user already did review
@@ -110,7 +110,7 @@ const DisplayProgramArea = (props: IDisplayProgramAreaProps) => {
             </div>
           ) : (
             <div className="d-flex align-items-center" key={index}>
-              {!allowUserReviewProgramArea() ||
+              {allowUserReviewProgramArea() ||
               Object(props.pia?.review?.programArea)?.reviews?.[role]
                 ?.isAcknowledged ? (
                 <ViewProgramAreaReview

--- a/src/frontend/src/components/public/PIAFormTabs/review/ProgamArea/displayProgramArea.tsx
+++ b/src/frontend/src/components/public/PIAFormTabs/review/ProgamArea/displayProgramArea.tsx
@@ -115,9 +115,7 @@ const DisplayProgramArea = (props: IDisplayProgramAreaProps) => {
             </div>
           ) : (
             <div className="d-flex align-items-center" key={index}>
-              {viewMode(role) ||
-              Object(props.pia?.review?.programArea)?.reviews?.[role]
-                ?.isAcknowledged ? (
+              {viewMode(role) ? (
                 <ViewProgramAreaReview
                   pia={props.pia}
                   role={role}

--- a/src/frontend/src/components/public/PIAFormTabs/review/ProgamArea/displayProgramArea.tsx
+++ b/src/frontend/src/components/public/PIAFormTabs/review/ProgamArea/displayProgramArea.tsx
@@ -37,7 +37,10 @@ const DisplayProgramArea = (props: IDisplayProgramAreaProps) => {
   const canEditProgramAreaReview =
     reviewPagePrivilegeParams?.editProgramAreaReview ?? false;
 
-  const allowUserReviewProgramArea = () => {
+  // Logic Explanation:
+  //   - When this function returns true, it means the readonly.
+  //   - When this function returns false, it means allow editing the review.
+  const viewUserReviewProgramArea = () => {
     if (canEditProgramAreaReview) return false;
 
     // if selectedRoles is null means none of selectedRole got reviewed so return true
@@ -110,7 +113,7 @@ const DisplayProgramArea = (props: IDisplayProgramAreaProps) => {
             </div>
           ) : (
             <div className="d-flex align-items-center" key={index}>
-              {allowUserReviewProgramArea() ||
+              {viewUserReviewProgramArea() ||
               Object(props.pia?.review?.programArea)?.reviews?.[role]
                 ?.isAcknowledged ? (
                 <ViewProgramAreaReview


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- [UTOPIA-1395](https://apps.itsm.gov.bc.ca/jira/browse/UTOPIA-1395)
- Fixed ambiguity in the logic that determines whether to display the view or edit section in each section
- Changed the function name: `allowUserReviewProgramArea` -> `viewUserReviewProgramArea` 

 | viewUserReviewProgramArea | isAcknowledged | Section |
|---------------------------|----------------|---------|
| false                     | false          | edit    |
| false                     | true           | view    |
| true                      | false          | view    |
| true                      | true           | view    |

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Updating Testing Framework(s)
- [ ] Version change

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Development Dependency Working Agreement
- [x] My code DOES NOT include the importing of new dependencies into the DPIA ecosystem
- [ ] My code DOES include the importing of new dependencies into the DPIA ecosystem
**If new dependencies are being introduced to the DPIA ecosystem:**
- [ ] The functionality of the dependency drastically reduces code complexity and makes my changes more easily maintainable and readable 
- [ ] The dependency being introduced does not contain multiple layers of nested dependencies introducing maintainability complexity to the DPIA ecosystem

## Frontend Development Changes
- [ ] N/A
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to project documentation or diagrams that reflect my changes
- [ ] New and existing unit tests pass locally with my changes
- [ ] My code follows Airbnb React Style Guidelines

## API Development Changes
- [x] N/A
- [ ] I have performed a self-review of my own code
- [ ] My code follows standards and practices outlined in the BC Government API Development Guidelines
- [ ] New and existing unit tests pass locally with my changes
- [ ] My changes includes Swagger documentation updates that reflect the changes I am introducing

## Definition of Done

![Definition of Done](https://raw.githubusercontent.com/bcgov/cirmo-dpia/main/.github/assets/DoD.jpg)
