### PR TITLE
[UTOPIA-980] Clicking “Edit” from View, user sees Edit mode of PIA intake instead of tab they are on

### DIFF
--- a/src/frontend/src/pages/PIAForm/index.tsx
+++ b/src/frontend/src/pages/PIAForm/index.tsx
@@ -208,41 +208,6 @@ const PIAFormPage = () => {
     }));
   };
 
-  /**
-   * @description - Check if the PIA is in an editable status
-   * @returns {boolean}
-   */
-
-  const checkEditableStatus = () => {
-    // the root cause is when the page loading, the pia does not exist,so it will
-    // use empty state object, which  this function always return true.
-    if (
-      pia?.status === PiaStatuses.INCOMPLETE ||
-      pia?.status === PiaStatuses.EDIT_IN_PROGRESS
-    ) {
-      return true;
-    }
-    return false;
-  };
-
-  /**
-   * @description - Navigate to the intake page upon status change to an
-   *                editable status or if the user changes the mode
-   */
-
-  useEffect(() => {
-    // for create new pia and next step page, bypass the check
-    if (pathname === routes.PIA_NEW) return;
-    if (pathname.split('/').includes('nextSteps')) return;
-    // temp fix, just use id instead of pia.id to make sure the app does not broken right now
-    if (checkEditableStatus() && mode === 'edit') {
-      navigate(buildDynamicPath(routes.PIA_INTAKE_EDIT, { id: id || pia?.id }));
-    } else if (checkEditableStatus() && mode === 'view') {
-      navigate(buildDynamicPath(routes.PIA_INTAKE_VIEW, { id: id || pia?.id }));
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [pia.status, mode]);
-
   const [formReadOnly, setFormReadOnly] = useState<boolean>(true);
 
   useEffect(() => {
@@ -526,7 +491,6 @@ const PIAFormPage = () => {
       console.error('PIA id not found');
       return;
     }
-    // the status will change to enum when Brandon pr merged
     if (pia.status === PiaStatuses.MPO_REVIEW) {
       handleShowModal('edit');
     } else {
@@ -634,12 +598,8 @@ const PIAFormPage = () => {
               ? PiaStatuses.EDIT_IN_PROGRESS
               : pia?.status,
         });
-        if (pia?.id && !pathname?.split('/').includes('review')) {
-          const regex = /(?<=\/)view/g;
-          navigate(pathname.replace(regex, 'edit'));
-        } else {
-          navigate(-1);
-        }
+        const regex = /(?<=\/)view/g;
+        navigate(pathname.replace(regex, 'edit'));
       } else if (buttonValue === 'save') {
         const newPia = await upsertAndUpdatePia();
         if (newPia?.id) {


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

[UTOPIA-980](https://apps.itsm.gov.bc.ca/jira/browse/UTOPIA-980)

- Removed code that was redirecting to intake page.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Updating Testing Framework(s)
- [ ] Version change

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Development Dependency Working Agreement
- [x] My code DOES NOT include the importing of new dependencies into the DPIA ecosystem
- [ ] My code DOES include the importing of new dependencies into the DPIA ecosystem
**If new dependencies are being introduced to the DPIA ecosystem:**
- [ ] The functionality of the dependency drastically reduces code complexity and makes my changes more easily maintainable and readable 
- [ ] The dependency being introduced does not contain multiple layers of nested dependencies introducing maintainability complexity to the DPIA ecosystem

## Frontend Development Changes
- [ ] N/A
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to project documentation or diagrams that reflect my changes
- [ ] New and existing unit tests pass locally with my changes
- [ ] My code follows Airbnb React Style Guidelines

## API Development Changes
- [x] N/A
- [ ] I have performed a self-review of my own code
- [ ] My code follows standards and practices outlined in the BC Government API Development Guidelines
- [ ] New and existing unit tests pass locally with my changes
- [ ] My changes includes Swagger documentation updates that reflect the changes I am introducing

## Definition of Done

![Definition of Done](https://raw.githubusercontent.com/bcgov/cirmo-dpia/main/.github/assets/DoD.jpg)
