### PR TITLE
[UTOPIA-1434] fix z-index to hide navbar and header on modal pop up

### DIFF
--- a/src/frontend/src/components/common/Navbar/_navbar.scss
+++ b/src/frontend/src/components/common/Navbar/_navbar.scss
@@ -9,7 +9,7 @@
   height: $navbar-height;
   width: 100%;
   background-color: $bg-blue;
-  z-index: 100;
+  z-index: 98;
 }
 
 .navbar {

--- a/src/frontend/src/components/public/PIASubHeader/_piasubheader.scss
+++ b/src/frontend/src/components/public/PIASubHeader/_piasubheader.scss
@@ -5,7 +5,7 @@
   height: $piaSubheader-height;
   width: 100%;
   background-color: $bg-white;
-  z-index: 100;
+  z-index: 98;
   box-shadow: 0 17px 29px 0 #dce2ee99;
   align-items: center;
   justify-content: space-between;


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

fix sign-out modal not fully covering background

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Updating Testing Framework(s)
- [ ] Version change

## How Has This Been Tested?

locally

## Development Dependency Working Agreement
- [x] My code DOES NOT include the importing of new dependencies into the DPIA ecosystem
- [ ] My code DOES include the importing of new dependencies into the DPIA ecosystem
**If new dependencies are being introduced to the DPIA ecosystem:**
- [ ] The functionality of the dependency drastically reduces code complexity and makes my changes more easily maintainable and readable 
- [ ] The dependency being introduced does not contain multiple layers of nested dependencies introducing maintainability complexity to the DPIA ecosystem

## Frontend Development Changes
- [ ] N/A
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to project documentation or diagrams that reflect my changes
- [ ] New and existing unit tests pass locally with my changes
- [ ] My code follows Airbnb React Style Guidelines

## API Development Changes
- [x] N/A
- [ ] I have performed a self-review of my own code
- [ ] My code follows standards and practices outlined in the BC Government API Development Guidelines
- [ ] New and existing unit tests pass locally with my changes
- [ ] My changes includes Swagger documentation updates that reflect the changes I am introducing

## Definition of Done

![Definition of Done](https://raw.githubusercontent.com/bcgov/cirmo-dpia/main/.github/assets/DoD.jpg)
