### PR TITLE
UTOPIA-1446: Updated keycloak-connect to 21.1.2

### DIFF
--- a/src/backend/package-lock.json
+++ b/src/backend/package-lock.json
@@ -19,7 +19,7 @@
         "class-transformer": "0.5.1",
         "dotenv": "16.0.2",
         "express": "4.18.2",
-        "keycloak-connect": "18.0.2",
+        "keycloak-connect": "21.1.2",
         "marked": "5.1.2",
         "morgan": "1.10.0",
         "nest-keycloak-connect": "1.9.2",
@@ -7188,14 +7188,15 @@
       }
     },
     "node_modules/keycloak-connect": {
-      "version": "18.0.2",
-      "resolved": "https://registry.npmjs.org/keycloak-connect/-/keycloak-connect-18.0.2.tgz",
-      "integrity": "sha512-FH7XgkPDPDIdIYkPpfp2S3++pJU+roprLDqmbptl6rZHP8DYzCdI/5DdC/hLFCVVhLhEzxMBtZGoqqnZ4icYww==",
+      "version": "21.1.2",
+      "resolved": "https://registry.npmjs.org/keycloak-connect/-/keycloak-connect-21.1.2.tgz",
+      "integrity": "sha512-ydRauaPu3lIlug1xlweAkV4N0InYf8QhkeWz0jzmjEyuPD88DHkGSQ5NcGyySAhMPPvKHISj1dty1Zs2uVu+EQ==",
+      "deprecated": "This package is deprecated and will be removed in the future. We will shortly provide more details on removal date, and recommended alternatives.",
       "dependencies": {
         "jwk-to-pem": "^2.0.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=14"
       },
       "optionalDependencies": {
         "chromedriver": "latest"

--- a/src/backend/package.json
+++ b/src/backend/package.json
@@ -39,7 +39,7 @@
     "class-transformer": "0.5.1",
     "dotenv": "16.0.2",
     "express": "4.18.2",
-    "keycloak-connect": "18.0.2",
+    "keycloak-connect": "21.1.2",
     "marked": "5.1.2",
     "morgan": "1.10.0",
     "nest-keycloak-connect": "1.9.2",


### PR DESCRIPTION
<!--  
PR Title format:  
JIRA_BOARD_ABBREVIATION-JIRA_TASK_NUMBER: TITLE_OF_JIRA_TASK  
-->

## 🎯 Summary

<!-- COMPLETE JIRA LINK BELOW -->  
[UTOPIA-1446](https://apps.itsm.gov.bc.ca/jira/browse/UTOPIA-1446)

<!-- PROVIDE BELOW an explanation of your changes and any images to support your explanation -->
Updated to `21.1.2` instead of `22.0.3` because of `nest-keycloak-connect` peer dependency requirements, but this version resolves Open redirect vulnerability.

## 🔰 Checklist

- [x] I have read and agree with the following checklist and am following the guidelines in our [Code of Conduct](/CODE_OF_CONDUCT.md) document.

> - I have performed a self-review of my code.
> - I have commented my code, particularly in hard-to-understand areas.
> - I have made corresponding changes to the documentation where required.
> - I have tested my changes to the best of my ability.
> - I have consulted with the team if introducing a new dependency.
> - My changes generate no new warnings.
