### PR TITLE
[UTOPIA-866] Match disabled text field UI for MPO use only text area

### DIFF
--- a/src/frontend/src/components/public/PIAFormTabs/collectionUseAndDisclosure/_collectionUseAndDisclosure.scss
+++ b/src/frontend/src/components/public/PIAFormTabs/collectionUseAndDisclosure/_collectionUseAndDisclosure.scss
@@ -1,0 +1,3 @@
+.w-md-editor-show-preview .w-md-editor-preview {
+  background-color: #e9ecef !important;
+}

--- a/src/frontend/src/components/public/PIAFormTabs/collectionUseAndDisclosure/index.tsx
+++ b/src/frontend/src/components/public/PIAFormTabs/collectionUseAndDisclosure/index.tsx
@@ -20,6 +20,7 @@ import {
 import ViewComments from '../../../common/ViewComment';
 import { PiaSections } from '../../../../types/enums/pia-sections.enum';
 import { TextInputEnum } from '../../../../constant/constant';
+import '../../PIAFormTabs/collectionUseAndDisclosure/_collectionUseAndDisclosure.scss';
 
 const PIACollectionUseAndDisclosure = ({
   showComments = true,

--- a/src/frontend/src/components/public/PIAFormTabs/collectionUseAndDisclosure/index.tsx
+++ b/src/frontend/src/components/public/PIAFormTabs/collectionUseAndDisclosure/index.tsx
@@ -20,7 +20,6 @@ import {
 import ViewComments from '../../../common/ViewComment';
 import { PiaSections } from '../../../../types/enums/pia-sections.enum';
 import { TextInputEnum } from '../../../../constant/constant';
-import '../../PIAFormTabs/collectionUseAndDisclosure/_collectionUseAndDisclosure.scss';
 
 const PIACollectionUseAndDisclosure = ({
   showComments = true,

--- a/src/frontend/src/components/public/PIAFormTabs/collectionUseAndDisclosure/index.tsx
+++ b/src/frontend/src/components/public/PIAFormTabs/collectionUseAndDisclosure/index.tsx
@@ -1,6 +1,6 @@
 import { useContext, useEffect, useMemo, useState } from 'react';
 import Messages from './messages';
-import MDEditor, { commands } from '@uiw/react-md-editor';
+import MDEditor from '@uiw/react-md-editor';
 import { isMPORole } from '../../../../utils/user';
 
 import {

--- a/src/frontend/src/components/public/PIAFormTabs/collectionUseAndDisclosure/index.tsx
+++ b/src/frontend/src/components/public/PIAFormTabs/collectionUseAndDisclosure/index.tsx
@@ -1,6 +1,6 @@
 import { useContext, useEffect, useMemo, useState } from 'react';
 import Messages from './messages';
-import MDEditor from '@uiw/react-md-editor';
+import MDEditor, { commands } from '@uiw/react-md-editor';
 import { isMPORole } from '../../../../utils/user';
 
 import {
@@ -89,6 +89,20 @@ const PIACollectionUseAndDisclosure = ({
         collectionUseAndDisclosureForm,
         'collectionUseAndDisclosure',
       );
+    }
+
+    // Disabled editor buttons if the user does not have the MPORole.
+    if (isMPORole() === false) {
+      // If the current user does not have the MPORole,
+      // select button elements inside #collectionNoticeMPO .w-md-editor-toolbar li.
+      const buttons = document.querySelectorAll<HTMLButtonElement>(
+        '#collectionNoticeMPO .w-md-editor-toolbar li > button',
+      );
+
+      // Iterate over all button elements and set the 'disabled' attribute to true.
+      buttons.forEach((button) => {
+        button.disabled = true;
+      });
     }
   }, [piaStateChangeHandler, collectionUseAndDisclosureForm, initialFormState]);
 

--- a/src/frontend/src/components/public/PIAFormTabs/collectionUseAndDisclosure/index.tsx
+++ b/src/frontend/src/components/public/PIAFormTabs/collectionUseAndDisclosure/index.tsx
@@ -92,18 +92,15 @@ const PIACollectionUseAndDisclosure = ({
     }
 
     // Disabled editor buttons if the user does not have the MPORole.
-    if (isMPORole() === false) {
-      // If the current user does not have the MPORole,
-      // select button elements inside #collectionNoticeMPO .w-md-editor-toolbar li.
-      const buttons = document.querySelectorAll<HTMLButtonElement>(
-        '#collectionNoticeMPO .w-md-editor-toolbar li > button',
-      );
+    // Select button elements inside #collectionNoticeMPO .w-md-editor-toolbar li.
+    const buttons = document.querySelectorAll<HTMLButtonElement>(
+      '#collectionNoticeMPO .w-md-editor-toolbar li > button',
+    );
 
-      // Iterate over all button elements and set the 'disabled' attribute to true.
-      buttons.forEach((button) => {
-        button.disabled = true;
-      });
-    }
+    // Iterate over all button elements and set the 'disabled' attribute based on the user's role.
+    buttons.forEach((button) => {
+      button.disabled = !isMPORole() ? true : false;
+    });
   }, [piaStateChangeHandler, collectionUseAndDisclosureForm, initialFormState]);
 
   return (

--- a/src/frontend/src/sass/common.scss
+++ b/src/frontend/src/sass/common.scss
@@ -38,3 +38,4 @@
 @import './collapsible';
 @import './printPreview';
 @import './comment_sidebar';
+@import '../components/public/PIAFormTabs/collectionUseAndDisclosure/collectionUseAndDisclosure';


### PR DESCRIPTION
<!--  
PR Title format:  
JIRA_BOARD_ABBREVIATION-JIRA_TASK_NUMBER: TITLE_OF_JIRA_TASK  
-->

## 🎯 Summary

<!-- COMPLETE JIRA LINK BELOW -->  
[UTOPIA-866](https://apps.itsm.gov.bc.ca/jira/browse/UTOPIA-866)

- Added separate CSS file for disabled editor to change the background color

<!-- PROVIDE BELOW an explanation of your changes and any images to support your explanation -->


## 🔰 Checklist

- [x] I have read and agree with the following checklist and am following the guidelines in our [Code of Conduct](/CODE_OF_CONDUCT.md) document.

> - I have performed a self-review of my code.
> - I have commented my code, particularly in hard-to-understand areas.
> - I have made corresponding changes to the documentation where required.
> - I have tested my changes to the best of my ability.
> - I have consulted with the team if introducing a new dependency.
> - My changes generate no new warnings.
