### PR TITLE
[UTOPIA-1478] User does not see full PIA after sharing with MPO from Next Steps page

### DIFF
--- a/src/frontend/src/components/public/PIAFormTabs/Next_Steps/nextStepsPI.tsx
+++ b/src/frontend/src/components/public/PIAFormTabs/Next_Steps/nextStepsPI.tsx
@@ -65,7 +65,8 @@ const NextStepsPI = (navigateFn: PIFlow) => {
           },
         });
 
-        // Update pia.isNextStepsSeenForDelegatedFlow to true
+        // This code changes the state when the "Share MPO" button is clicked
+        // in order to make the delegated full PIA visible on the tab.
         piaStateChangeHandler(true, 'isNextStepsSeenForDelegatedFlow');
 
         break;

--- a/src/frontend/src/components/public/PIAFormTabs/Next_Steps/nextStepsPI.tsx
+++ b/src/frontend/src/components/public/PIAFormTabs/Next_Steps/nextStepsPI.tsx
@@ -66,8 +66,8 @@ const NextStepsPI = (navigateFn: PIFlow) => {
         });
 
         // This code changes the state when the "Share MPO" button is clicked
-        // in order to make the delegated full PIA visible on the tab.
-        piaStateChangeHandler(true, 'isNextStepsSeenForDelegatedFlow');
+        // in order to make the non delegated full PIA visible on the tab.
+        piaStateChangeHandler(true, 'isNextStepsSeenForNonDelegatedFlow');
 
         break;
       case 'incomplete':

--- a/src/frontend/src/components/public/PIAFormTabs/Next_Steps/nextStepsPI.tsx
+++ b/src/frontend/src/components/public/PIAFormTabs/Next_Steps/nextStepsPI.tsx
@@ -64,6 +64,10 @@ const NextStepsPI = (navigateFn: PIFlow) => {
             statusChange: PiaStatuses.EDIT_IN_PROGRESS,
           },
         });
+
+        // Update pia.isNextStepsSeenForDelegatedFlow to true
+        piaStateChangeHandler(true, 'isNextStepsSeenForDelegatedFlow');
+
         break;
       case 'incomplete':
         setNextStepAction({

--- a/src/frontend/src/components/public/PIASideNav/pia-form-sideNav-pages.ts
+++ b/src/frontend/src/components/public/PIASideNav/pia-form-sideNav-pages.ts
@@ -21,11 +21,13 @@ export const PiaFormSideNavPages = (
   const { pathname } = useLocation();
 
   // This will change once Next Steps tab is implemented
+  // This code determines whether to show post-intake tabs based on two conditions:
+  // 1. hasAddedPiToDataElements is not false.
+  // 2. Either isNextStepsSeenForNonDelegatedFlow is true, or isNextStepsSeenForDelegatedFlow is true.
   const showPostIntakeTabs =
-    ((pia?.hasAddedPiToDataElements === true ||
-      pia?.hasAddedPiToDataElements === null) &&
-      pia?.isNextStepsSeenForNonDelegatedFlow === true) ||
-    pia?.isNextStepsSeenForDelegatedFlow === true;
+    (pia?.hasAddedPiToDataElements !== false &&
+      pia?.isNextStepsSeenForNonDelegatedFlow) ||
+    pia?.isNextStepsSeenForDelegatedFlow;
 
   const checkPIANonDelegateFlow = (): boolean => {
     return (

--- a/src/frontend/src/components/public/PIASideNav/pia-form-sideNav-pages.ts
+++ b/src/frontend/src/components/public/PIASideNav/pia-form-sideNav-pages.ts
@@ -22,9 +22,10 @@ export const PiaFormSideNavPages = (
 
   // This will change once Next Steps tab is implemented
   const showPostIntakeTabs =
-    (pia?.hasAddedPiToDataElements === true ||
+    ((pia?.hasAddedPiToDataElements === true ||
       pia?.hasAddedPiToDataElements === null) &&
-    pia?.isNextStepsSeenForNonDelegatedFlow === true;
+      pia?.isNextStepsSeenForNonDelegatedFlow === true) ||
+    pia?.isNextStepsSeenForDelegatedFlow === true;
 
   const checkPIANonDelegateFlow = (): boolean => {
     return (

--- a/src/frontend/src/components/public/PIASideNav/pia-form-sideNav-pages.ts
+++ b/src/frontend/src/components/public/PIASideNav/pia-form-sideNav-pages.ts
@@ -25,9 +25,8 @@ export const PiaFormSideNavPages = (
   // 1. hasAddedPiToDataElements is not false.
   // 2. Either isNextStepsSeenForNonDelegatedFlow is true, or isNextStepsSeenForDelegatedFlow is true.
   const showPostIntakeTabs =
-    (pia?.hasAddedPiToDataElements !== false &&
-      pia?.isNextStepsSeenForNonDelegatedFlow) ||
-    pia?.isNextStepsSeenForDelegatedFlow;
+    pia?.hasAddedPiToDataElements !== false &&
+    pia?.isNextStepsSeenForNonDelegatedFlow;
 
   const checkPIANonDelegateFlow = (): boolean => {
     return (


### PR DESCRIPTION
<!--  
PR Title format:  
JIRA_BOARD_ABBREVIATION-JIRA_TASK_NUMBER: TITLE_OF_JIRA_TASK  
-->

## 🎯 Summary

<!-- COMPLETE JIRA LINK BELOW -->  
[UTOPIA-1478](https://apps.itsm.gov.bc.ca/jira/browse/UTOPIA-1478)

- Changes state when the "Share MPO" button is clicked to make it visible on the tab.
- Simplified the condition in the showPostIntakeTabs variable to improve readability.
- Added comments

<!-- PROVIDE BELOW an explanation of your changes and any images to support your explanation -->


## 🔰 Checklist

- [x] I have read and agree with the following checklist and am following the guidelines in our [Code of Conduct](/CODE_OF_CONDUCT.md) document.

> - I have performed a self-review of my code.
> - I have commented my code, particularly in hard-to-understand areas.
> - I have made corresponding changes to the documentation where required.
> - I have tested my changes to the best of my ability.
> - I have consulted with the team if introducing a new dependency.
> - My changes generate no new warnings.
