### PR TITLE
[UTOPIA-1423] User can see review data after moving PIA from Final Review > CPO Review or MPO Review

### DIFF
--- a/src/frontend/src/components/public/PIAFormTabs/review/ProgramArea/PADisplay.tsx
+++ b/src/frontend/src/components/public/PIAFormTabs/review/ProgramArea/PADisplay.tsx
@@ -25,7 +25,8 @@ export const ProgramAreaDisplay = (props: IDisplayProgramAreaProps) => {
     ?.review?.params;
   const canEditProgramAreaReviewers =
     reviewPagePrivilegeParams?.editProgramAreaReviewers ?? false;
-
+  // Check if the privilege to show Program Area Review is enabled.
+  const showPAReview = reviewPagePrivilegeParams?.showProgramAreaReview;
   const deleteRole = useCallback(
     (roleIndex: number) => {
       const updatedRoles = [...reviewForm.programArea.selectedRoles];
@@ -53,24 +54,44 @@ export const ProgramAreaDisplay = (props: IDisplayProgramAreaProps) => {
       {canEditProgramAreaReviewers && <h4 className="mb-3">Selected Roles</h4>}
       {selectedRoles.length > 0 ? (
         selectedRoles.map((role: string, index: number) => {
+          const isRoleReviewed = reviewForm.programArea?.reviews?.[role];
           return canEditProgramAreaReviewers ? (
             <div
               key={index}
               className="d-flex gap-1 justify-content-start align-items-center"
             >
-              <p className="m-0 pt-2">{role}</p>
-              {mandatoryADM && role === ApprovalRoles.ADM ? (
-                <p className="m-0 pt-2 error-text">(required for this PIA)</p>
-              ) : null}
-              {!reviewForm.programArea?.reviews?.[role] &&
-                !(mandatoryADM && role === ApprovalRoles.ADM) && (
-                  <button
-                    className="bcgovbtn bcgovbtn__tertiary bcgovbtn__tertiary--negative ps-3"
-                    onClick={() => deleteRole(index)}
-                  >
-                    <FontAwesomeIcon className="" icon={faTrash} size="xl" />
-                  </button>
-                )}
+              {/* Display Program Area Review Card if the privilege is enabled and the role has a review. */}
+              {showPAReview && isRoleReviewed ? (
+                <ProgramAreaReviewCard
+                  pia={pia}
+                  printPreview={printPreview}
+                  role={role}
+                  stateChangeHandler={stateChangeHandler}
+                />
+              ) : (
+                <>
+                  <p className="m-0 pt-2">{role}</p>
+                  {mandatoryADM && role === ApprovalRoles.ADM ? (
+                    <p className="m-0 pt-2 error-text">
+                      (required for this PIA)
+                    </p>
+                  ) : null}
+
+                  {!isRoleReviewed &&
+                    !(mandatoryADM && role === ApprovalRoles.ADM) && (
+                      <button
+                        className="bcgovbtn bcgovbtn__tertiary bcgovbtn__tertiary--negative ps-3"
+                        onClick={() => deleteRole(index)}
+                      >
+                        <FontAwesomeIcon
+                          className=""
+                          icon={faTrash}
+                          size="xl"
+                        />
+                      </button>
+                    )}
+                </>
+              )}
             </div>
           ) : (
             <div className="d-flex align-items-center" key={index}>


### PR DESCRIPTION
<!--  
PR Title format:  
JIRA_BOARD_ABBREVIATION-JIRA_TASK_NUMBER: TITLE_OF_JIRA_TASK  
-->

## 🎯 Summary

<!-- COMPLETE JIRA LINK BELOW -->  
[UTOPIA-1423](https://apps.itsm.gov.bc.ca/jira/browse/UTOPIA-1423)

<!-- PROVIDE BELOW an explanation of your changes and any images to support your explanation -->
- Changed to show the PA review data on the CPO, MPO status from Final Status

## 🔰 Checklist

- [x] I have read and agree with the following checklist and am following the guidelines in our [Code of Conduct](/CODE_OF_CONDUCT.md) document.

> - I have performed a self-review of my code.
> - I have commented my code, particularly in hard-to-understand areas.
> - I have made corresponding changes to the documentation where required.
> - I have tested my changes to the best of my ability.
> - I have consulted with the team if introducing a new dependency.
> - My changes generate no new warnings.
