### PR TITLE
[UTOPIA-1236]CPO should not be able to skip MPO review

### DIFF
--- a/src/frontend/src/utils/statusList/statuses/editInProgressStatus.ts
+++ b/src/frontend/src/utils/statusList/statuses/editInProgressStatus.ts
@@ -71,10 +71,6 @@ export const editInProgressStatus = () => {
             status: 'INCOMPLETE',
             modal: defaultIncompleteModal,
           },
-          {
-            status: 'CPO_REVIEW',
-            modal: defaultCPOReviewModal,
-          },
         ],
       },
       DRAFTER: {

--- a/src/frontend/src/utils/statusList/statuses/incompleteStatus.ts
+++ b/src/frontend/src/utils/statusList/statuses/incompleteStatus.ts
@@ -81,10 +81,6 @@ export const incompleteStatus = (pia: IPiaForm | null) => {
             modal: defaultEditInProgressModal,
           },
           {
-            status: 'CPO_REVIEW',
-            modal: defaultCPOReviewModal,
-          },
-          {
             status: 'INCOMPLETE',
             modal: defaultIncompleteModal,
             submitModal: submitPiaIntakeModal,

--- a/src/frontend/src/utils/statusList/statuses/mpoReviewStatus.ts
+++ b/src/frontend/src/utils/statusList/statuses/mpoReviewStatus.ts
@@ -90,10 +90,6 @@ export const mpoReviewStatus = (pia: IPiaForm | null) => {
         },
         changeStatus: [
           {
-            status: 'CPO_REVIEW',
-            modal: defaultCPOReviewModal,
-          },
-          {
             status: 'INCOMPLETE',
             modal: checkReviewStatus(pia)
               ? resetReviewIncompleteModal


### PR DESCRIPTION
<!--  
PR Title format:  
JIRA_BOARD_ABBREVIATION-JIRA_TASK_NUMBER: TITLE_OF_JIRA_TASK  
-->

## 🎯 Summary

<!-- COMPLETE JIRA LINK BELOW -->  
[UTOPIA-1236](https://apps.itsm.gov.bc.ca/jira/browse/UTOPIA-1236)

<!-- PROVIDE BELOW an explanation of your changes and any images to support your explanation -->
- Remove the privilege for CPO users to change a CPO Review Status change dropdown in the "Incomplete," "Edit in progress," and "MPO review" statuses

## 🔰 Checklist

- [x] I have read and agree with the following checklist and am following the guidelines in our [Code of Conduct](/CODE_OF_CONDUCT.md) document.

> - I have performed a self-review of my code.
> - I have commented my code, particularly in hard-to-understand areas.
> - I have made corresponding changes to the documentation where required.
> - I have tested my changes to the best of my ability.
> - I have consulted with the team if introducing a new dependency.
> - My changes generate no new warnings.
