### PR TITLE
[UTOPIA - 1611] - Autosave triggering on empty PIA

### DIFF
--- a/src/frontend/src/components/common/Dropdown/index.tsx
+++ b/src/frontend/src/components/common/Dropdown/index.tsx
@@ -9,6 +9,7 @@ const Dropdown = ({
   changeHandler,
   required,
   readOnly = false,
+  disabled = false,
 }: IDropdown) => {
   return (
     <div className={`form-group ${optionalClass}`}>
@@ -26,6 +27,7 @@ const Dropdown = ({
             onChange={changeHandler}
             required={required}
             aria-label={label ?? id}
+            disabled={disabled}
           >
             <option key={id} value="">
               {placeholder || 'Select one'}

--- a/src/frontend/src/components/common/Dropdown/interfaces.ts
+++ b/src/frontend/src/components/common/Dropdown/interfaces.ts
@@ -15,4 +15,5 @@ export interface IDropdown {
   changeHandler?: ChangeEventHandler<HTMLSelectElement>;
   required?: boolean;
   readOnly?: boolean;
+  disabled?: boolean;
 }

--- a/src/frontend/src/components/common/InputText/InputText.tsx
+++ b/src/frontend/src/components/common/InputText/InputText.tsx
@@ -4,6 +4,7 @@ import { faUpRightFromSquare } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { TextInputEnum } from '../../../constant/constant';
 import { InputTextProps } from './interfaces';
+import { Tooltip } from '../Tooltip';
 
 const InputText = ({
   id = '',
@@ -26,6 +27,10 @@ const InputText = ({
   isAccessLink = false,
   maxLength,
   autoFocus = false,
+  tooltipLabel = '',
+  tooltipDirection = 'right',
+  tooltipShowIcon = false,
+  tooltipContent = '',
 }: InputTextProps) => {
   // Generating an input ID from the label, or using a provided ID
   const inputId = id || (label && convertLabelToId(label)) || '';
@@ -113,6 +118,12 @@ const InputText = ({
         <label className={labelSide === 'left' ? 'mt-0' : ''} htmlFor={inputId}>
           {label}
           {required && <span className="error-text "> (required)</span>}
+          <Tooltip
+            label={tooltipLabel}
+            direction={tooltipDirection}
+            showIcon={tooltipShowIcon}
+            content={tooltipContent}
+          />
         </label>
       )}
       {/* Helper text and optional link rendering */}

--- a/src/frontend/src/components/common/InputText/InputText.tsx
+++ b/src/frontend/src/components/common/InputText/InputText.tsx
@@ -25,16 +25,21 @@ const InputText = ({
   readOnly = false,
   isAccessLink = false,
   maxLength,
+  autoFocus = false,
 }: InputTextProps) => {
-  // default to converted id from label if "id" is not provided
+  // Generating an input ID from the label, or using a provided ID
   const inputId = id || (label && convertLabelToId(label)) || '';
 
+  // Constructing CSS classes based on the label position
   let labelSideClasses = ' ';
   labelSideClasses += labelSide === 'top' ? 'flex-column ' : 'flex-row ';
   labelSideClasses += labelSide === 'left' ? 'align-items-center ' : ' ';
 
-  const inputRef = useRef<HTMLInputElement | HTMLTextAreaElement>(null);
+  // Refs for input and textarea elements
+  const inputRef = useRef<HTMLInputElement>(null);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
 
+  // Callback for handling 'Enter' key events
   const keydownListener = useCallback(
     (e: any) => {
       if (e.code === 'Enter' || e.code === 'NumpadEnter') {
@@ -44,8 +49,9 @@ const InputText = ({
     [onEnter],
   );
 
+  // Effect for attaching the 'Enter' keydown event listener
   useEffect(() => {
-    const currentInput = inputRef.current;
+    const currentInput = inputRef.current || textareaRef.current;
 
     if (!currentInput) return;
 
@@ -56,10 +62,23 @@ const InputText = ({
     };
   }, [keydownListener]);
 
+  // Effect for auto-focusing the input or textarea when the component mounts
+  useEffect(() => {
+    if (autoFocus) {
+      if (type === TextInputEnum.INPUT_TEXT_AREA && textareaRef.current) {
+        textareaRef.current.focus();
+      } else if (inputRef.current) {
+        inputRef.current.focus();
+      }
+    }
+  }, [autoFocus, type]);
+
+  // Function to check if the current type is a textarea
   const checkTextArea = () => {
     return type === TextInputEnum.INPUT_TEXT_AREA;
   };
 
+  // Common properties for input and textarea elements
   const commonProps = {
     id: inputId,
     value: value || '',
@@ -74,11 +93,13 @@ const InputText = ({
     maxLength,
   };
 
+  // Properties specific to input elements
   const inputProps = {
     ...commonProps,
     type,
   };
 
+  // Properties specific to textarea elements
   const textareaProps = {
     ...commonProps,
   };
@@ -87,12 +108,14 @@ const InputText = ({
     <div
       className={`input-text-container form-group d-flex ${labelSideClasses} ${className}`}
     >
+      {/* Label rendering with conditional requirement indicator */}
       {label && (
         <label className={labelSide === 'left' ? 'mt-0' : ''} htmlFor={inputId}>
           {label}
           {required && <span className="error-text "> (required)</span>}
         </label>
       )}
+      {/* Helper text and optional link rendering */}
       {helperText !== '' && (
         <p className="form-group__p--margin-zero">
           <span className="pe-1">{helperText}</span>
@@ -107,11 +130,12 @@ const InputText = ({
           </a>
         </p>
       )}
+      {/* Conditional rendering for editable and read-only states */}
       {!readOnly ? (
         checkTextArea() ? (
-          <textarea {...textareaProps} />
+          <textarea ref={textareaRef} {...textareaProps} />
         ) : (
-          <input {...inputProps} />
+          <input ref={inputRef} {...inputProps} />
         )
       ) : value ? (
         <p>{value}</p>

--- a/src/frontend/src/components/common/InputText/interfaces.ts
+++ b/src/frontend/src/components/common/InputText/interfaces.ts
@@ -4,6 +4,7 @@ import {
   FocusEventHandler,
 } from 'react';
 import { TextType } from '../../../types/types/text.type';
+import { TooltipProps } from '../Tooltip/interfaces';
 
 export interface InputTextProps {
   id?: string;
@@ -26,4 +27,8 @@ export interface InputTextProps {
   isAccessLink?: boolean;
   maxLength?: number;
   autoFocus?: boolean;
+  tooltipLabel?: TooltipProps['label'];
+  tooltipDirection?: TooltipProps['direction'];
+  tooltipShowIcon?: TooltipProps['showIcon'];
+  tooltipContent?: TooltipProps['content'];
 }

--- a/src/frontend/src/components/common/InputText/interfaces.ts
+++ b/src/frontend/src/components/common/InputText/interfaces.ts
@@ -25,4 +25,5 @@ export interface InputTextProps {
   readOnly?: boolean;
   isAccessLink?: boolean;
   maxLength?: number;
+  autoFocus?: boolean;
 }

--- a/src/frontend/src/components/common/ViewComment/index.tsx
+++ b/src/frontend/src/components/common/ViewComment/index.tsx
@@ -5,7 +5,11 @@ import {
   PiaFormContext,
 } from '../../../contexts/PiaFormContext';
 
-const ViewComments = ({ path, count = 0 }: ViewCommentProps) => {
+const ViewComments = ({
+  path,
+  count = 0,
+  disabled = false,
+}: ViewCommentProps) => {
   const { piaCollapsibleChangeHandler, piaCommentPathHandler } =
     useContext<IPiaFormContext>(PiaFormContext);
 
@@ -21,6 +25,7 @@ const ViewComments = ({ path, count = 0 }: ViewCommentProps) => {
         aria-label="View comments"
         className="bcgovbtn bcgovbtn__tertiary bold"
         onClick={openSidebar}
+        disabled={disabled}
       >
         View comments ({count ? +count : 0})
       </button>

--- a/src/frontend/src/components/common/ViewComment/interfaces.ts
+++ b/src/frontend/src/components/common/ViewComment/interfaces.ts
@@ -4,6 +4,7 @@ export default interface ViewCommentProps {
   comments?: Comment[];
   path: PiaSections | undefined;
   count?: number;
+  disabled?: boolean;
 }
 
 export interface CommentCount {

--- a/src/frontend/src/components/public/PIAFormTabs/intake/components/IntakeGeneralInformation.tsx
+++ b/src/frontend/src/components/public/PIAFormTabs/intake/components/IntakeGeneralInformation.tsx
@@ -17,6 +17,7 @@ const IntakeGeneralInformation: React.FC<IntakeGeneralInformationProps> = ({
   validationMessage,
   pia,
   path,
+  disabled,
 }) => {
   // State to hold the full name of the selected ministry
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -112,6 +113,7 @@ const IntakeGeneralInformation: React.FC<IntakeGeneralInformationProps> = ({
               (e) => stateChangeHandler(e?.target?.value || null, 'ministry') // empty string to null conversion
             }
             required={true}
+            disabled={disabled}
           />
           {/* Error message for ministry */}
           {validationMessage.piaMinistry && (
@@ -125,6 +127,7 @@ const IntakeGeneralInformation: React.FC<IntakeGeneralInformationProps> = ({
             value={intakeForm?.branch}
             required={true}
             onChange={(e) => stateChangeHandler(e.target.value, 'branch')}
+            isDisabled={disabled}
           />
           {/* Error message for branch */}
           {validationMessage.piaBranch && (
@@ -141,6 +144,7 @@ const IntakeGeneralInformation: React.FC<IntakeGeneralInformationProps> = ({
             value={intakeForm?.leadName}
             onChange={(e) => stateChangeHandler(e.target.value, 'leadName')}
             required={false}
+            isDisabled={disabled}
           />
         </div>
         <div className="col">
@@ -152,6 +156,7 @@ const IntakeGeneralInformation: React.FC<IntakeGeneralInformationProps> = ({
             onChange={(e) => stateChangeHandler(e.target.value, 'leadEmail')}
             required={false}
             type="email"
+            isDisabled={disabled}
           />
         </div>
       </div>
@@ -164,6 +169,7 @@ const IntakeGeneralInformation: React.FC<IntakeGeneralInformationProps> = ({
             value={intakeForm?.leadTitle}
             onChange={(e) => stateChangeHandler(e.target.value, 'leadTitle')}
             required={false}
+            isDisabled={disabled}
           />
         </div>
       </div>
@@ -171,6 +177,7 @@ const IntakeGeneralInformation: React.FC<IntakeGeneralInformationProps> = ({
       <ViewComments
         count={commentCount?.[PiaSections.INTAKE_GENERAL_INFORMATION]}
         path={PiaSections.INTAKE_GENERAL_INFORMATION}
+        disabled={disabled}
       />
     </div>
   );

--- a/src/frontend/src/components/public/PIAFormTabs/intake/components/IntakeGeneralInformation.tsx
+++ b/src/frontend/src/components/public/PIAFormTabs/intake/components/IntakeGeneralInformation.tsx
@@ -94,6 +94,12 @@ const IntakeGeneralInformation: React.FC<IntakeGeneralInformationProps> = ({
           onChange={(e) => stateChangeHandler(e.target.value, 'title')}
           required={true}
           autoFocus={true}
+          tooltipShowIcon={true}
+          tooltipLabel="Initiative title"
+          tooltipContent={
+            <p>{Messages.GeneralInfoSection.TooltipContent.en}</p>
+          }
+          tooltipDirection="right"
         />
         {/* Error message for initiative title */}
         {validationMessage.piaTitle && (

--- a/src/frontend/src/components/public/PIAFormTabs/intake/components/IntakeGeneralInformation.tsx
+++ b/src/frontend/src/components/public/PIAFormTabs/intake/components/IntakeGeneralInformation.tsx
@@ -92,6 +92,7 @@ const IntakeGeneralInformation: React.FC<IntakeGeneralInformationProps> = ({
           value={intakeForm?.title}
           onChange={(e) => stateChangeHandler(e.target.value, 'title')}
           required={true}
+          autoFocus={true}
         />
         {/* Error message for initiative title */}
         {validationMessage.piaTitle && (

--- a/src/frontend/src/components/public/PIAFormTabs/intake/components/IntakeInitiativeDescription.tsx
+++ b/src/frontend/src/components/public/PIAFormTabs/intake/components/IntakeInitiativeDescription.tsx
@@ -19,6 +19,7 @@ const IntakeInitiativeDescription: React.FC<
   validationMessage,
   selectedSection,
   commentCount,
+  disabled,
 }) => {
   // State for initiativeDescription text editor.
   const [initiativeDescription, setInitiativeDescription] = useState(
@@ -72,7 +73,7 @@ const IntakeInitiativeDescription: React.FC<
             <RichTextEditor
               content={initiativeDescription}
               setContent={setInitiativeDescription}
-              readOnly={isReadOnly}
+              readOnly={isReadOnly || disabled}
               aria-label="Initiative Description Textarea Input"
             />
           ) : (
@@ -93,6 +94,7 @@ const IntakeInitiativeDescription: React.FC<
             commentCount?.[PiaSections.INTAKE_INITIATIVE_DETAILS_DESCRIPTION]
           }
           path={PiaSections.INTAKE_INITIATIVE_DETAILS_DESCRIPTION}
+          disabled={disabled}
         />
       </div>
     </section>

--- a/src/frontend/src/components/public/PIAFormTabs/intake/components/IntakeInitiativeDetails.tsx
+++ b/src/frontend/src/components/public/PIAFormTabs/intake/components/IntakeInitiativeDetails.tsx
@@ -15,6 +15,7 @@ const IntakeInitiativeDetails: React.FC<IntakeInitiativeDetailsProps> = ({
   intakeForm,
   stateChangeHandler,
   commentCount,
+  disabled,
 }) => {
   // Calculate if the current section is focused
   const isSectionFocused =
@@ -60,7 +61,7 @@ const IntakeInitiativeDetails: React.FC<IntakeInitiativeDetailsProps> = ({
             <RichTextEditor
               content={dataElementsInvolved}
               setContent={setDataElementsInvolved}
-              readOnly={isReadOnly}
+              readOnly={isReadOnly || disabled}
               aria-label="Data Elements Involved Textarea Input"
             />
           ) : (
@@ -76,6 +77,7 @@ const IntakeInitiativeDetails: React.FC<IntakeInitiativeDetailsProps> = ({
             ]
           }
           path={PiaSections.INTAKE_INITIATIVE_DETAILS_DATA_ELEMENTS_INVOLVED}
+          disabled={disabled}
         />
       </div>
     </section>

--- a/src/frontend/src/components/public/PIAFormTabs/intake/components/IntakeInitiativeScope.tsx
+++ b/src/frontend/src/components/public/PIAFormTabs/intake/components/IntakeInitiativeScope.tsx
@@ -11,6 +11,7 @@ const IntakeInitiativeScope: React.FC<IntakeInitiativeScopeProps> = ({
   intakeForm,
   stateChangeHandler,
   commentCount,
+  disabled,
 }) => {
   // Determine section focus based on selectedSection
   const sectionFocus =
@@ -58,7 +59,7 @@ const IntakeInitiativeScope: React.FC<IntakeInitiativeScopeProps> = ({
             <RichTextEditor
               content={initiativeScope}
               setContent={setInitiativeScope}
-              readOnly={isReadOnly}
+              readOnly={isReadOnly || disabled}
               aria-label="Initiative Scope Textarea Input"
             />
           ) : (
@@ -70,6 +71,7 @@ const IntakeInitiativeScope: React.FC<IntakeInitiativeScopeProps> = ({
         <ViewComments
           count={commentCount?.[PiaSections.INTAKE_INITIATIVE_DETAILS_SCOPE]}
           path={PiaSections.INTAKE_INITIATIVE_DETAILS_SCOPE}
+          disabled={disabled}
         />
       </div>
     </section>

--- a/src/frontend/src/components/public/PIAFormTabs/intake/components/IntakePersonalInformation.tsx
+++ b/src/frontend/src/components/public/PIAFormTabs/intake/components/IntakePersonalInformation.tsx
@@ -20,6 +20,7 @@ const IntakePersonalInformation: React.FC<IntakePersonalInformationProps> = ({
   commentCount,
   pia,
   handlePIOptionChange,
+  disabled,
 }) => {
   // Determine the class to apply for section focus
   const sectionClass =
@@ -74,7 +75,7 @@ const IntakePersonalInformation: React.FC<IntakePersonalInformationProps> = ({
           PIOptions.map((option, index) => (
             <label key={index} className="form__input-label input-label-row">
               <input
-                disabled={isReadOnly}
+                disabled={isReadOnly || disabled}
                 type="radio"
                 name="pi-options-radio"
                 aria-label={`Did you list personal information in the last question? ${option.key}`}
@@ -129,6 +130,7 @@ const IntakePersonalInformation: React.FC<IntakePersonalInformationProps> = ({
         <ViewComments
           count={commentCount?.[PiaSections.INTAKE_PERSONAL_INFORMATION]}
           path={PiaSections.INTAKE_PERSONAL_INFORMATION}
+          disabled={disabled}
         />
       </div>
     </section>

--- a/src/frontend/src/components/public/PIAFormTabs/intake/helper/messages.ts
+++ b/src/frontend/src/components/public/PIAFormTabs/intake/helper/messages.ts
@@ -36,7 +36,7 @@ export default {
     },
     MPOLinkHref: `https://www2.gov.bc.ca/gov/content/governments/services-for-government/information-management-technology/privacy/resources/privacy-officers`,
     TooltipContent: {
-      en: `To enable saving, please enter a title.`,
+      en: `Please enter a title to enable saving.`,
     },
   },
   InitiativeDescriptionSection: {

--- a/src/frontend/src/components/public/PIAFormTabs/intake/helper/messages.ts
+++ b/src/frontend/src/components/public/PIAFormTabs/intake/helper/messages.ts
@@ -35,6 +35,9 @@ export default {
       en: `Ministry Privacy Officer (MPO) Directory`,
     },
     MPOLinkHref: `https://www2.gov.bc.ca/gov/content/governments/services-for-government/information-management-technology/privacy/resources/privacy-officers`,
+    TooltipContent: {
+      en: `To enable saving, please enter a title.`,
+    },
   },
   InitiativeDescriptionSection: {
     SectionHeading: {

--- a/src/frontend/src/components/public/PIAFormTabs/intake/helper/pia-form-intake.interface.ts
+++ b/src/frontend/src/components/public/PIAFormTabs/intake/helper/pia-form-intake.interface.ts
@@ -35,6 +35,7 @@ export interface IntakeInitiativeScopeProps extends PIAInformationProps {
     nestedKey?: keyof RichTextContent,
   ) => void;
   commentCount?: IPiaFormContext['commentCount'];
+  disabled?: boolean;
 }
 
 export interface IntakeGeneralInformationProps

--- a/src/frontend/src/components/public/PIAFormTabs/intake/index.tsx
+++ b/src/frontend/src/components/public/PIAFormTabs/intake/index.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent, useContext, useState } from 'react';
+import { ChangeEvent, useContext, useEffect, useState } from 'react';
 import { exportIntakeFromPia } from './helper/extract-intake-from-pia.helper';
 import { IPiaFormIntake } from './helper/pia-form-intake.interface';
 import {
@@ -32,6 +32,15 @@ export const PIAFormIntake = () => {
   const [intakeForm, setIntakeForm] = useState<IPiaFormIntake>(
     exportIntakeFromPia(pia),
   );
+
+  // State to manage the disabled status
+  const [disabled, setDisabled] = useState(false);
+
+  useEffect(() => {
+    // Check if pia.title exists and is not just empty spaces.
+    // If there's no text, set 'disabled' to true, otherwise false.
+    setDisabled(pia?.title?.trim().length === 0);
+  }, [pia?.title]);
 
   // Handle changes to the intake form state
   const stateChangeHandler = (
@@ -80,6 +89,7 @@ export const PIAFormIntake = () => {
         commentCount={commentCount}
         pia={pia}
         path={selectedSection}
+        disabled={disabled}
       />
 
       {/* Render the intake initiative description section */}
@@ -90,6 +100,7 @@ export const PIAFormIntake = () => {
         validationMessage={validationMessage}
         selectedSection={selectedSection}
         commentCount={commentCount}
+        disabled={disabled}
       />
 
       {/* Render the intake initiative scope section */}
@@ -99,6 +110,7 @@ export const PIAFormIntake = () => {
         stateChangeHandler={stateChangeHandler}
         selectedSection={selectedSection}
         commentCount={commentCount}
+        disabled={disabled}
       />
 
       {/* Render the intake initiative details section */}
@@ -108,6 +120,7 @@ export const PIAFormIntake = () => {
         stateChangeHandler={stateChangeHandler}
         selectedSection={selectedSection}
         commentCount={commentCount}
+        disabled={disabled}
       />
 
       {/* Render the intake personal information section */}
@@ -118,6 +131,7 @@ export const PIAFormIntake = () => {
         stateChangeHandler={stateChangeHandler}
         commentCount={commentCount}
         handlePIOptionChange={handlePIOptionChange}
+        disabled={disabled}
       />
     </>
   );

--- a/src/frontend/src/utils/autosave.ts
+++ b/src/frontend/src/utils/autosave.ts
@@ -13,13 +13,28 @@ import { deepEqual } from './object-comparison.util';
 import useSnowPlow from './snowplow';
 import { PiaStatuses } from '../constant/constant';
 import useHandleModal from '../pages/PIAForm/utils/handleModal';
+import { RichTextContent } from '../components/public/PIAFormTabs/types';
 
 const useAutoSave = () => {
   const navigate = useNavigate();
   const { pathname, search } = useLocation();
 
   // Define initial state
+  const emptyRichTextContent: RichTextContent = { content: '' };
   const emptyState: IPiaForm = {
+    id: undefined,
+    title: '',
+    ministry: undefined,
+    branch: '',
+    leadName: '',
+    leadTitle: '',
+    leadEmail: '',
+    mpoName: '',
+    mpoEmail: '',
+    initiativeDescription: emptyRichTextContent,
+    initiativeScope: emptyRichTextContent,
+    dataElementsInvolved: emptyRichTextContent,
+    riskMitigation: emptyRichTextContent,
     hasAddedPiToDataElements: true,
     status: PiaStatuses.DRAFTING_IN_PROGRESS,
   };
@@ -52,7 +67,6 @@ const useAutoSave = () => {
   // Upsert and update PIA form
   const upsertAndUpdatePia = useCallback(
     async (changes: Partial<IPiaForm> = {}) => {
-      console.log('Upsert and update PIA called with changes:', changes);
       const hasExplicitChanges = Object.keys(changes).length > 0;
       if (!hasExplicitChanges && !hasFormChanged()) return pia;
 

--- a/src/frontend/src/utils/autosave.ts
+++ b/src/frontend/src/utils/autosave.ts
@@ -156,6 +156,7 @@ const useAutoSave = () => {
     const autoSave = async () => {
       setIsEagerSave(false);
       if (isConflict) return;
+      if (pia?.title?.trim().length === 0) return;
 
       try {
         await upsertAndUpdatePia();

--- a/src/frontend/src/utils/object-comparison.util.ts
+++ b/src/frontend/src/utils/object-comparison.util.ts
@@ -11,6 +11,9 @@ export const deepEqual = (
   object2: any,
   skipKeys: Array<string> = [],
 ) => {
+  const trimString = (value: any) =>
+    typeof value === 'string' ? value.trim() : value;
+
   if (
     typeof object1 !== 'object' ||
     typeof object2 !== 'object' ||
@@ -24,7 +27,7 @@ export const deepEqual = (
       object2 = convertToISODate(object2);
     }
 
-    return object1 === object2;
+    return trimString(object1) === trimString(object2);
   }
 
   const keys1 = Object.keys(object1);
@@ -38,21 +41,21 @@ export const deepEqual = (
     if (skipKeys.includes(key)) continue;
 
     // recursive check for nested values [objects]
-    if (
-      typeof object1[key] === typeof object2[key] &&
-      typeof object1[key] === 'object' &&
-      object1[key] !== null &&
-      object1[key] !== undefined &&
-      object2[key] !== null &&
-      object2[key] !== undefined
-    ) {
-      if (deepEqual(object1[key], object2[key])) continue;
+    const val1 = trimString(object1[key]);
+    const val2 = trimString(object2[key]);
 
+    if (
+      typeof val1 === 'object' &&
+      val1 !== null &&
+      typeof val2 === 'object' &&
+      val2 !== null
+    ) {
+      if (deepEqual(val1, val2, skipKeys)) continue;
       return false;
     }
 
     // check for primitive values
-    if (object1[key] !== object2[key]) {
+    if (val1 !== val2) {
       return false;
     }
   }


### PR DESCRIPTION
<!--  
PR Title format:  
JIRA_BOARD_ABBREVIATION-JIRA_TASK_NUMBER: TITLE_OF_JIRA_TASK  
-->

## 🎯 Summary

<!-- COMPLETE JIRA LINK BELOW -->  
[UTOPIA-1611](https://apps.itsm.gov.bc.ca/jira/browse/UTOPIA-1611)

<!-- PROVIDE BELOW an explanation of your changes and any images to support your explanation -->
- make deepEqual function trim spaces when checking for differences between objects
- make the title field immediately be focused so that users can type right away
- make the other fields disabled until the title field is filled out first (no spaces)
- stop autosave from starting when a pia is clicked and only triggered when title is filled out with actual text
- add tooltip to title field

## 🔰 Checklist

- [x] I have read and agree with the following checklist and am following the guidelines in our [Code of Conduct](/CODE_OF_CONDUCT.md) document.

> - I have performed a self-review of my code.
> - I have commented my code, particularly in hard-to-understand areas.
> - I have made corresponding changes to the documentation where required.
> - I have tested my changes to the best of my ability.
> - I have consulted with the team if introducing a new dependency.
> - My changes generate no new warnings.
