### PR TITLE
UTOPIA-1539: Fix migration

### DIFF
--- a/src/backend/src/migrations/1701983062936-FixNewIntakeColumn.ts
+++ b/src/backend/src/migrations/1701983062936-FixNewIntakeColumn.ts
@@ -1,0 +1,26 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class FixNewIntakeColumn1701983062936 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // Add column that was mistakenly removed in last migration
+    await queryRunner.query(
+      `ALTER TABLE "pia-intake" ADD "new_intake" boolean`,
+    );
+
+    // Setting new_intake to true where status is 'DRAFTING_IN_PROGRESS'
+    await queryRunner.query(
+      `UPDATE "pia-intake" SET "new_intake" = true WHERE "status" = 'DRAFTING_IN_PROGRESS'`,
+    );
+
+    // Setting new_intake to false where status is not 'DRAFTING_IN_PROGRESS'
+    await queryRunner.query(
+      `UPDATE "pia-intake" SET "new_intake" = false WHERE "status" <> 'DRAFTING_IN_PROGRESS'`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "pia-intake" DROP COLUMN "new_intake"`,
+    );
+  }
+}


### PR DESCRIPTION
<!--  
PR Title format:  
JIRA_BOARD_ABBREVIATION-JIRA_TASK_NUMBER: TITLE_OF_JIRA_TASK  
-->

## 🎯 Summary

<!-- COMPLETE JIRA LINK BELOW -->  
[UTOPIA-1539](https://apps.itsm.gov.bc.ca/jira/browse/UTOPIA-1539)

<!-- PROVIDE BELOW an explanation of your changes and any images to support your explanation -->
- Previous migration for adding reply table seemed to remove the new_intake property (Happens when generating a migration before pulling main when main has another migration that has been run on the database but is not reflected in the current branches code).
- Added new_intake property to existing records.

## 🔰 Checklist

- [x] I have read and agree with the following checklist and am following the guidelines in our [Code of Conduct](/CODE_OF_CONDUCT.md) document.

> - I have performed a self-review of my code.
> - I have commented my code, particularly in hard-to-understand areas.
> - I have made corresponding changes to the documentation where required.
> - I have tested my changes to the best of my ability.
> - I have consulted with the team if introducing a new dependency.
> - My changes generate no new warnings.
